### PR TITLE
Quick fix for blog redirect url for cloudfront hosting

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -56,7 +56,7 @@ callouts:
 
 callout_button:
     title: I want to know more about OpenSearch
-    url: /blog
+    url: /blog/index.html
 
 opendistro:
     head:  Looking for Open Distro?


### PR DESCRIPTION
This is a Quick fix for blog redirect url for cloudfront hosting
Cloudfront only allows root default file to be index.html, cannot redirect subdirectory index.html like /blog/index.html