### PR TITLE
Add a possibility to run/serve the site via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,18 @@ If you discover potential security issues, see the reporting instructions on our
 This project is licensed under the BSD-3-Clause License.
 
 ## Build
+You can build the site and make it available on a local server via: 
+```
+docker-compose up -d
+```
+or by installing all the dependencies on your local environment:
 
 1. Go to the root of the repo
 2. Install [Ruby](https://www.ruby-lang.org/en/) and [RVM](https://rvm.io/)
 3. Install [Jekyll](https://jekyllrb.com/)
 4. Install dependencies: `bundle install`
 5. Build: `bundle exec jekyll serve` for the local server, `bundle exec jekyll build` for one off builds. Either way, the HTML of the site is generated to `/_site`
-6. Point your browser at [`http://127.0.0.1:4000/`](http://127.0.0.1:4000/)
 
-## Docker
-Start a local server via: 
-```
-docker-compose up -d
-```
 and then browse the site at [`http://127.0.0.1:4000/`](http://127.0.0.1:4000/).
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ This project is licensed under the BSD-3-Clause License.
 3. Install [Jekyll](https://jekyllrb.com/)
 4. Install dependencies: `bundle install`
 5. Build: `bundle exec jekyll serve` for the local server, `bundle exec jekyll build` for one off builds. Either way, the HTML of the site is generated to `/_site`
-6. Point your browser at `http://127.0.0.1:4000/`
+6. Point your browser at [`http://127.0.0.1:4000/`](http://127.0.0.1:4000/)
 
+## Docker
+Start a local server via: 
+```
+docker-compose up -d
+```
+and then browse the site at [`http://127.0.0.1:4000/`](http://127.0.0.1:4000/).
 ## Credit
 
 This website was forked from the BSD-licensed [djangoproject.com](https://github.com/django/djangoproject.com)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.2'
+
+services:
+  jekyll:
+    build: ./docker/
+    container_name: opensearch-project-website
+    volumes:
+      - .:/srv/jekyll
+    ports:
+      - '4000:4000'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,10 @@
-FROM ruby:alpine3.13 as jekyll
-
-RUN apk add --no-cache build-base gcc bash cmake git
-
-RUN gem install bundler -v "~>2.2.11" && gem install jekyll
-
-EXPOSE 4000
-
-ENTRYPOINT [ "jekyll" ]
-
-FROM jekyll/jekyll:4.2.0 as jekyll-serve
+FROM jekyll/jekyll:4.2.0 as jekyll
 
 COPY run.sh /usr/local/bin/
 RUN chmod a+x /usr/local/bin/run.sh
 
 ENTRYPOINT [ "run.sh" ]
+
+EXPOSE 4000
 
 CMD [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:alpine3.13 as jekyll
+
+RUN apk add --no-cache build-base gcc bash cmake git
+
+RUN gem install bundler -v "~>2.2.11" && gem install jekyll
+
+EXPOSE 4000
+
+ENTRYPOINT [ "jekyll" ]
+
+FROM jekyll/jekyll:4.2.0 as jekyll-serve
+
+COPY run.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/run.sh
+
+ENTRYPOINT [ "run.sh" ]
+
+CMD [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+if [ ! -f Gemfile ]; then
+  echo "No Gemfile file found!"
+  exit 1
+fi
+
+bundle install --retry 5 --jobs 20
+
+exec "$@"


### PR DESCRIPTION
### Description
This PR provides an easy way to setup/serve the site locally using a light way (Docker) instead of dealing with the dependency hell while installing all the dependencies for using Jekyll.
 
### Issues Resolved
n/a
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
