### PR TITLE
fixed issue with deployed site throwing 404

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,8 +37,7 @@ layout: default
 <div role="complementary">
     {% for author_short_name in page.authors %}
         {% assign author = site.authors | where: 'short_name', author_short_name | first %}
-        {% comment %}<h2><a href="{{ author.url }}">{{ author.name }}</a></h2>{% endcomment %}
-        <h2>{{ author.name }}</h2>
+        <h2><a href="{{ author.url }}.html">{{ author.name }}</a></h2>
         {% if author.photo  %} <img class="author-photo" src="{{ author.photo }}" alt="photo of {{author.name}}" /> {% endif %}
         
         <p>{{ author.content | markdownify }}</p>


### PR DESCRIPTION
(missing `.html` on authors link was causing a 404 error when deployed to s3)