### PR TITLE
Add information about PGP keys to homepage

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -78,7 +78,13 @@ layout: default
           <p>{{ page.opendistro.description }}</p>
           <a href="{{ page.opendistro.link.url }}" class="link-readmore">{{ page.opendistro.link.title }}</a>
         </div>
-        
+
+        <h3>{{ page.signatures.head }}</h3>
+        <div class="feature-content">
+          <p>{{ page.signatures.description }}</p>
+          <a href="{{ page.signatures.link.url }}" class="link-readmore">{{ page.signatures.link.title }}</a>
+        </div>
+
       </div>
       
       <div class="whats-new">

--- a/index.markdown
+++ b/index.markdown
@@ -46,6 +46,15 @@ opendistro:
         url: http://opendistro.github.io/for-elasticsearch/
         title: Find it here
 
+signatures:
+  head: "How to verify signatures"
+  description: "Download our PGP key using the link below and import it. If you're using gpg, you just need to run `gpg --import /path/to/key`. You can then verify the signature by downloading it into the same directory where you downloaded the tarball, and running `gpg --verify /path/to/signature /path/to/tarball`. It should show a good signature signed by opensearch@amazon.com.
+
+  Our current PGP key fingerprint is C2EE 2AF6 542C 03B4"
+  link:
+    url: https://artifacts.opensearch.org/publickeys/opensearch.pgp
+    title: Our PGP key
+
 secondary:
     heading: 'Stay in the loop'
     content: "Check out the [forums](https://discuss.opendistrocommunity.dev/) to stay informed."


### PR DESCRIPTION
### Description
Adds information about downloading and importing our PGP key, and how to verify signatures.
 

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
