### PR TITLE
Fix ruby install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+- [opensearch.org website](#opensearchorg-website)
+  - [Contributing](#contributing)
+    - [Adding to the Partners Page](#adding-to-the-partners-page)
+  - [Security](#security)
+  - [License](#license)
+  - [Build](#build)
+  - [Credits](#credits)
+  
 # opensearch.org website
 
 This repo contains the source for the opensearch.org website. 
@@ -6,7 +14,7 @@ This repo contains the source for the opensearch.org website.
 
 We welcome contributions! Please see our [CONTRIBUTING](CONTRIBUTING.md) page to learn more about how to contribute to the website.
 
-### Adding to the partners page
+### Adding to the Partners Page
 
 If you are a partner, you are welcome to add your logo/link to our partners page. See the [sample file](https://github.com/opensearch-project/project-website/blob/staging/_partners/_sample.md) and submit a pull request.
 
@@ -15,9 +23,11 @@ If you are a partner, you are welcome to add your logo/link to our partners page
 If you discover potential security issues, see the reporting instructions on our [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) page for more information.
 
 ## License
+
 This project is licensed under the BSD-3-Clause License.
 
 ## Build
+
 You can build the site and make it available on a local server via: 
 ```
 docker-compose up -d
@@ -25,12 +35,13 @@ docker-compose up -d
 or by installing all the dependencies on your local environment:
 
 1. Go to the root of the repo
-2. Install [Ruby](https://www.ruby-lang.org/en/) and [RVM](https://rvm.io/)
+2. Install [Ruby](https://www.ruby-lang.org/en/)
 3. Install [Jekyll](https://jekyllrb.com/)
 4. Install dependencies: `bundle install`
-5. Build: `bundle exec jekyll serve` for the local server, `bundle exec jekyll build` for one off builds. Either way, the HTML of the site is generated to `/_site`
+5. Build: `bundle exec jekyll serve` for the local server, `bundle exec jekyll build` for one off builds. Either way, the HTML of the site is generated to `/_site`.
 
-and then browse the site at [`http://127.0.0.1:4000/`](http://127.0.0.1:4000/).
-## Credit
+Browse the site at [`http://127.0.0.1:4000/`](http://127.0.0.1:4000/).
+
+## Credits
 
 This website was forked from the BSD-licensed [djangoproject.com](https://github.com/django/djangoproject.com)


### PR DESCRIPTION
### Description

Noticed that our instructions for installing ruby here are incorrect. RVM is one option to install Ruby (it manages multiple ruby installations), and if we wanted to recommend RVM we would say "install RVM, then install Ruby". But since YMMV with how you like to install Ruby (e.g via rvm or rbenv), then we should have no opinion.

Added automatic TOC, fixed some minor stuff.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
