### PR TITLE
Fixed twitter links and added GitHub.

### DIFF
--- a/_authors/alolitas.markdown
+++ b/_authors/alolitas.markdown
@@ -1,7 +1,7 @@
 ---
 name: Alolita Sharma
 short_name: alolitas
-twitter: '@alolita'
+twitter: 'alolita'
 photo: '/assets/media/authors/alolitas.png'
 ---
 

--- a/_authors/amistrn.markdown
+++ b/_authors/amistrn.markdown
@@ -1,7 +1,7 @@
 ---
 name: Amitai Stern
 short_name: amistrn
-twitter: '@amitaistern'
+twitter: 'amitaistern'
 photo: '/assets/media/authors/amistrn.jpg'
 ---
 

--- a/_authors/dblock.markdown
+++ b/_authors/dblock.markdown
@@ -2,6 +2,8 @@
 name: Daniel (dB.) Doubrovkine
 short_name: dblock
 photo: '/assets/media/authors/dblock.jpg'
+twitter: 'dblockdotorg'
+github: dblock
 ---
 
 **Daniel (dB.) Doubrovkine** is a Principal Engineer at AWS, focusing on OpenSearch plugins. 

--- a/_authors/handler.markdown
+++ b/_authors/handler.markdown
@@ -2,7 +2,7 @@
 name: Jon Handler
 short_name: handler
 photo: '/assets/media/authors/handler.jpg'
-twitter: '@_searchgeek'
+twitter: '_searchgeek'
 ---
 
 **Jon Handler** is a Principal Solutions Architect at Amazon Web Services based in Palo Alto, CA. Jon works closely with the CloudSearch and Elasticsearch teams, providing help and guidance to a broad range of customers who have search workloads that they want to move to the AWS Cloud. Prior to joining AWS, Jon's career as a software developer included four years of coding a large-scale, eCommerce search engine. Jon holds a Bachelor of the Arts from the University of Pennsylvania, and a Master of Science and a Ph. D. in Computer Science and Artificial Intelligence from Northwestern University.

--- a/_authors/kyledvs.markdown
+++ b/_authors/kyledvs.markdown
@@ -2,7 +2,7 @@
 name: Kyle Davis
 short_name: kyledvs
 photo: '/assets/media/authors/kyledvs.jpg'
-twitter: '@stockholmux'
+twitter: 'stockholmux'
 ---
 
 Kyle Davis is the Senior Developer Advocate for OpenSearch and Open Distro for Elasticsearch. 

--- a/_authors/virajph.markdown
+++ b/_authors/virajph.markdown
@@ -1,7 +1,7 @@
 ---
 short_name: virajph
 name: Viraj Phanse
-twitter: '@vrphanse'
+twitter: 'vrphanse'
 github: vrphanse
 ---
 

--- a/_includes/author_panel.html
+++ b/_includes/author_panel.html
@@ -15,7 +15,12 @@
 <p>{{ include.author.content | markdownify }}</p>
 
 <div class="author-social-media">
+  <ul>
 {% if include.author.twitter %}
-  <a href="https://twitter.com/{{include.author.auttwitter}}"><i class="icon icon-twitter-square"></i> {{include.author.twitter}}</a>
+    <li><a target="_blank" href="https://twitter.com/{{include.author.twitter}}"><i class="icon icon-twitter-square"></i> {{include.author.twitter}}</a></li>
 {% endif %}
+{% if include.author.github %}
+    <li><a target="_blank" href="https://github.com/{{include.author.github}}"><i class="icon icon-github-square"></i> {{include.author.github}}</a>
+{% endif %}</li>
+  </ul>
 </div>

--- a/_sass/_opensearch.scss
+++ b/_sass/_opensearch.scss
@@ -269,4 +269,8 @@ dl.list-features {
     a {
         text-decoration: none;
     }
+    ul {
+        list-style-type: none;
+        padding-left: 0;
+    }
 }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Twitter links have a typo, fixed. Removed `@` which is redundant, even though Twitter redirects.
 
Added GitHub.

<img width="422" alt="Screen Shot 2021-06-08 at 8 25 46 PM" src="https://user-images.githubusercontent.com/542335/121274094-bbb8cf00-c897-11eb-9b64-bf719d303445.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
