### PR TITLE
docker-compose.yml sample: post OpenSearch-Dashboard to both OpenSearch nodes

### DIFF
--- a/samples/docker-compose.yml
+++ b/samples/docker-compose.yml
@@ -55,13 +55,16 @@ services:
     expose:
       - "5601"
     environment:
-      OPENSEARCH_HOSTS: https://opensearch-node1:9200
+      OPENSEARCH_HOSTS: '["https://opensearch-node1:9200","https://opensearch-node2:9200"]'
     networks:
       - opensearch-net
 
 volumes:
   opensearch-data1:
+    driver: local
   opensearch-data2:
+    driver: local
 
 networks:
   opensearch-net:
+    driver: bridge

--- a/samples/docker-compose.yml
+++ b/samples/docker-compose.yml
@@ -61,10 +61,7 @@ services:
 
 volumes:
   opensearch-data1:
-    driver: local
   opensearch-data2:
-    driver: local
 
 networks:
   opensearch-net:
-    driver: bridge


### PR DESCRIPTION
### Description
Configure docker-compose.yml to have OpenSearch-Dashboards talk to both OpenSearch nodes.

### Issues Resolved
OpenSearch-Dashboards only talk to one of the two hosts 

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
