### PR TITLE
updates the upgrade FAQ section title to be more specific 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-19
-  x86_64-linux-musl
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.2.0)
@@ -84,4 +84,4 @@ DEPENDENCIES
   wdm (~> 0.1.1)
 
 BUNDLED WITH
-   2.2.11
+   2.2.19

--- a/_faqs/03-01-how-can-i-upgrade-a-cluster-with-multiple-nodes-to-opensearch.markdown
+++ b/_faqs/03-01-how-can-i-upgrade-a-cluster-with-multiple-nodes-to-opensearch.markdown
@@ -1,6 +1,6 @@
 ---
 question: How can I upgrade an Elasticsearch OSS and Kibana OSS cluster with multiple nodes to OpenSearch and OpenSearch Dashboards?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 OpenSearch supports rolling upgrades in the same way as Elasticsearch OSS. You can deploy OpenSearch into a mixed cluster with Elasticsearch OSS or Open Distro for Elasticsearch nodes. One by one you can replace the legacy nodes with little to no additional manual work.
  

--- a/_faqs/03-02-how-can-i-upgrade-a-single-node-deployment.markdown
+++ b/_faqs/03-02-how-can-i-upgrade-a-single-node-deployment.markdown
@@ -1,6 +1,6 @@
 ---
 question: How can I upgrade a single node deployment of Elasticsearch OSS and Kibana OSS to OpenSearch and OpenSearch Dashboards?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 You are able to stop Elasticsearch OSS and Kibana OSS, install OpenSearch and OpenSearch Dashboards, manually configure those to point to your Elasticsearch OSS and Kibana OSS data, review and potentially update settings, then start OpenSearch with OpenSearch Dashboards. 
 

--- a/_faqs/03-03-which-versions-of-elasticsearch-oss-and-kibana-can-i-upgrade-from-to-opensearch-and-opensearch-dashboards-directly.markdown
+++ b/_faqs/03-03-which-versions-of-elasticsearch-oss-and-kibana-can-i-upgrade-from-to-opensearch-and-opensearch-dashboards-directly.markdown
@@ -1,5 +1,5 @@
 ---
 question: Which versions of Elasticsearch OSS and Kibana OSS can I upgrade from to OpenSearch and OpenSearch Dashboards, directly?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Elasticsearch OSS and Kibana OSS 6.8.0 to 7.10.2 and Open Distro for Elasticsearch (ODFE) 1.x.

--- a/_faqs/03-04-can-i-upgrade-older-versions-of-elasticsearch-oss-and-kibana-to-opensearch-and-opensearch-dashboards.markdown
+++ b/_faqs/03-04-can-i-upgrade-older-versions-of-elasticsearch-oss-and-kibana-to-opensearch-and-opensearch-dashboards.markdown
@@ -1,6 +1,6 @@
 ---
 question: Can I upgrade older versions of Elasticsearch OSS and Kibana OSS to OpenSearch and OpenSearch Dashboards?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Elasticsearch OSS and Kibana OSS 5.x up to 6.7.2 can be first upgraded to 6.8.0, then it is recommended to upgrade to Elasticsearch OSS 7.10.2 or ODFE 1.13, before upgrading to OpenSearch and OpenSearch Dashboards.
 

--- a/_faqs/03-05-can-i-upgrade-a-non-oss-cluster.markdown
+++ b/_faqs/03-05-can-i-upgrade-a-non-oss-cluster.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I upgrade a non-OSS Elasticsearch and Kibana cluster to OpenSearch?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Yes. However, functionality not available in Elasticsearch OSS and Kibana OSS continues to not be available. We recommend evaluating additional features available in OpenSearch that may provide similar functionality.

--- a/_faqs/03-06-can-i-upgrade-from-elasticsearch-and-kibana-7.11-or-other-versions-released-after-the-fork.markdown
+++ b/_faqs/03-06-can-i-upgrade-from-elasticsearch-and-kibana-7.11-or-other-versions-released-after-the-fork.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I upgrade from Elasticsearch and Kibana 7.11 or other versions released after the fork?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 No, this will not be supported in OpenSearch 1.0.

--- a/_faqs/03-07-will-my-odfe-plugins-continue-to-work-after-upgrade.markdown
+++ b/_faqs/03-07-will-my-odfe-plugins-continue-to-work-after-upgrade.markdown
@@ -1,5 +1,5 @@
 ---
 question: Will my ODFE plugins continue to work after upgrade?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 OpenSearch plugins based on the Open Distro for Elasticsearch (ODFE) plugins are included in OpenSearch 1.0, and are functionally backwards compatible with their predecessors.

--- a/_faqs/03-08-at-what-point-is-the-upgrade-process-complete.markdown
+++ b/_faqs/03-08-at-what-point-is-the-upgrade-process-complete.markdown
@@ -1,5 +1,5 @@
 ---
 question: At what point is the upgrade process complete?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 When all nodes are running OpenSearch and OpenSearch Dashboards 1.0.

--- a/_faqs/03-09-does-an-upgrade-require-downtime.markdown
+++ b/_faqs/03-09-does-an-upgrade-require-downtime.markdown
@@ -1,5 +1,5 @@
 ---
 question: Does an upgrade to OpenSearch require downtime?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 You can perform rolling upgrades from Elasticsearch OSS to OpenSearch, which does not require downtime. Kibana OSS upgrades require a restart which will cause downtime for Kibana OSS and OpenSearch Dashboards. If you have a single-node deployment and wish to upgrade it in-place, you will incur downtime.

--- a/_faqs/03-10-can-i-do-a-blue-green-upgrade-with-data-migration.markdown
+++ b/_faqs/03-10-can-i-do-a-blue-green-upgrade-with-data-migration.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I do a Blue/Green upgrade with data migration?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Yes. You can choose to do a Blue/Green upgrade instead of a rolling upgrade.

--- a/_faqs/03-11-can-i-install-elasticsearch-xyz-plugin-in-opensearch.markdown
+++ b/_faqs/03-11-can-i-install-elasticsearch-xyz-plugin-in-opensearch.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I install elasticsearch-xyz-plugin in OpenSearch?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 An Elasticsearch plugin that depends on Elasticsearch JARs will not work without code changes to depend on OpenSearch JARs.

--- a/_faqs/03-12-can-i-rollback-an-upgrade-half-way-in-progress-e-g-2-4-nodes-are-running-opensearch.markdown
+++ b/_faqs/03-12-can-i-rollback-an-upgrade-half-way-in-progress-e-g-2-4-nodes-are-running-opensearch.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I rollback an upgrade half-way in progress (e.g. 2/4 nodes are running OpenSearch)?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 This is possible and has caveats. For example, upgrading Kibana OSS to OpenSearch Dashboards migrates the Kibana OSS indexes and does not allow rollback. 

--- a/_faqs/03-13-are-there-any-changes-required-for-my-existing-elasticsearch-clients-to-continue-to-work.markdown
+++ b/_faqs/03-13-are-there-any-changes-required-for-my-existing-elasticsearch-clients-to-continue-to-work.markdown
@@ -1,5 +1,5 @@
 ---
 question: Are there any changes required for my existing Elasticsearch OSS clients to continue to work?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 While the OpenSearch API is backwards compatible, some clients or tools may include code, such as version checks, that may cause the client or tool to not work with OpenSearch. 

--- a/_faqs/03-14-can-i-run-a-heterogeneous-mixed-opensearch-and-elasticsearch-cluster-.markdown
+++ b/_faqs/03-14-can-i-run-a-heterogeneous-mixed-opensearch-and-elasticsearch-cluster-.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I run a heterogeneous mixed OpenSearch and Elasticsearch OSS cluster?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 This only supported in OpenSearch for the purpose of a rolling upgrade.

--- a/_faqs/03-15-can-i-run-a-heterogeneous-mixed-opensearch-dashboards-and-kibana-cluster-.markdown
+++ b/_faqs/03-15-can-i-run-a-heterogeneous-mixed-opensearch-dashboards-and-kibana-cluster-.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I run a heterogeneous mixed OpenSearch Dashboards and Kibana cluster?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 No. This is not supported.

--- a/_faqs/03-16-is-opensearch-security-enabled-by-default-after-an-upgrade.markdown
+++ b/_faqs/03-16-is-opensearch-security-enabled-by-default-after-an-upgrade.markdown
@@ -1,5 +1,5 @@
 ---
 question: Is OpenSearch security enabled by default after an upgrade?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Yes. Security is enabled by default.

--- a/_faqs/03-17-what-settings-change-during-the-upgrade.markdown
+++ b/_faqs/03-17-what-settings-change-during-the-upgrade.markdown
@@ -1,6 +1,6 @@
 ---
 question: What settings change during the upgrade?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Environment variables that contain branded words such as `ES` or `OPENDISTRO` have been renamed. 
 

--- a/_faqs/03-18-what-rest-apis-change-during-the-upgrade.markdown
+++ b/_faqs/03-18-what-rest-apis-change-during-the-upgrade.markdown
@@ -1,5 +1,5 @@
 ---
 question: What REST APIs change during the upgrade?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 REST APIs that contain branded words such as `ES` or `OPENDISTRO` have been deprecated.

--- a/_faqs/03-19-how-do-we-upgrade-or-migrate-secure-or-system-indices.markdown
+++ b/_faqs/03-19-how-do-we-upgrade-or-migrate-secure-or-system-indices.markdown
@@ -1,5 +1,5 @@
 ---
 question: How do I upgrade or migrate secure or system indices?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 There is no need to migrate secure or system indices for the upgrade to OpenSearch 1.0. This is because theses indices are not being renamed. In future upgrades, index aliases or migrations may be introduced for secure or system indices.

--- a/_faqs/03-20-is-there-binary-compatibility-between-elasticsearch-oss-and-opensearch.markdown
+++ b/_faqs/03-20-is-there-binary-compatibility-between-elasticsearch-oss-and-opensearch.markdown
@@ -1,5 +1,5 @@
 ---
 question: Is there binary compatibility between Elasticsearch-OSS and OpenSearch?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 While an OpenSearch node is able to join an Elasticsearch OSS cluster, namespaces and class names in OpenSearch have been changed. If your plugin code depends on Elasticsearch OSS JARs, you will need to upgrade those dependencies to OpenSearch JARs.

--- a/_faqs/03-21-where-can-i-find-more-information-and-track-progress-on-ensuring-backwards-compatibility.markdown
+++ b/_faqs/03-21-where-can-i-find-more-information-and-track-progress-on-ensuring-backwards-compatibility.markdown
@@ -1,5 +1,5 @@
 ---
 question: Where can I find more information and track progress on ensuring backwards compatibility?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 The umbrella issue for backwards-compatibility is [OpenSearch#671](https://github.com/opensearch-project/OpenSearch/issues/671). Issues across opensearch-project repositories are labeled *backwards-compatibility*.

--- a/_faqs/03-22-will-kibana-work-on-top-of-opensearch.markdown
+++ b/_faqs/03-22-will-kibana-work-on-top-of-opensearch.markdown
@@ -1,5 +1,5 @@
 ---
 question: Will Kibana work on top of OpenSearch 1.0?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 No. You will need to upgrade to OpenSearch Dashboards.

--- a/_faqs/03-23-i-have-built-a-custom-plugin-for-elasticsearch-will-it-run-without-modification-on-opensearch.markdown
+++ b/_faqs/03-23-i-have-built-a-custom-plugin-for-elasticsearch-will-it-run-without-modification-on-opensearch.markdown
@@ -1,5 +1,5 @@
 ---
 question: I have built a custom plugin for Elasticsearch, will it run without modification on OpenSearch?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Because OpenSearch is backwards compatible, it will. If you find identify an incompatibility, please open and issue in OpenSearch.

--- a/_faqs/03-24-can-i-install-kibana-xyz-plugin-that-only-uses-rest-apis-in-opensearch-dashboards-1.0.markdown
+++ b/_faqs/03-24-can-i-install-kibana-xyz-plugin-that-only-uses-rest-apis-in-opensearch-dashboards-1.0.markdown
@@ -1,5 +1,5 @@
 ---
 question: Can I install kibana-xyz-plugin that only uses REST APIs in OpenSearch Dashboards 1.0?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 While the APIs have not changed, we have not tested kibana-xyz-plugin.

--- a/_faqs/03-25-i-have-built-a-custom-visualization-for-kibana-will-it-be-usable-with-opensearch-dashboards-without-modification.markdown
+++ b/_faqs/03-25-i-have-built-a-custom-visualization-for-kibana-will-it-be-usable-with-opensearch-dashboards-without-modification.markdown
@@ -1,5 +1,5 @@
 ---
 question: I have built a custom visualization for Kibana, will it be usable with OpenSearch Dashboards without modification?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 Because OpenSearch Dashboards is backwards compatible, it will. If you find identify an incompatibility, please open and issue in OpenSearch Dashboards.

--- a/_faqs/03-26-can-opensearch-read-indices-from-previous-versions-of-elasticsearch.markdown
+++ b/_faqs/03-26-can-opensearch-read-indices-from-previous-versions-of-elasticsearch.markdown
@@ -1,6 +1,6 @@
 ---
 question: Can OpenSearch read indices from previous versions of Elasticsearch?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 
 Yes. OpenSearch is compatible with indices created from Elasticsearch versions 6.0 up to 7.10.

--- a/_faqs/03-27-will-the-opensearch-api-change-in-future-versions.markdown
+++ b/_faqs/03-27-will-the-opensearch-api-change-in-future-versions.markdown
@@ -1,6 +1,6 @@
 ---
 question: Will the OpenSearch API change in future versions?
-category: Upgrading
+category: Upgrading to OpenSearch
 ---
 
 All future OpenSearch 1.x releases will be backwards compatible with Elasticsearch 7.10. If functionality requires a breaking change, we will introduce a new major version of OpenSearch and provide tooling to make migrating to the new major version simple. When new features require adding APIs, we will work with the community to add support for these features in popular clients.


### PR DESCRIPTION
updates the upgrade FAQ section title to specifically say "Upgrading to OpenSearch." _Upgrading_ might be perceived as upgrading from OpenSearch 1.x to 1.y. However, these FAQs are focused upgrading from open source ES and ODFE to OpenSearch.

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
