### PR TITLE
Visual updates to partners page

### DIFF
--- a/_layouts/fullwidth.html
+++ b/_layouts/fullwidth.html
@@ -4,6 +4,6 @@ layout: default
 
 {% assign primary_title = page.primary_title %}
 {% include copy_banner.html %}
-<div class="container">
+<main class="container">
     {{ content }}
-</div>
+</main>

--- a/_sass/_opensearch.scss
+++ b/_sass/_opensearch.scss
@@ -168,19 +168,6 @@ dl.list-features {
     }
 }
 
-#partners {
-    .partner {
-        text-align: center;
-        float: left;
-
-        width: 100px;
-        img {
-            height: 60px;
-            width: 60px;
-        }
-    }
-}
-
 .img-fluid {
     max-width: 100%;
     height: auto;

--- a/_sass/_partners.scss
+++ b/_sass/_partners.scss
@@ -14,14 +14,12 @@
 
     @include respond-min(580px) {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(Min(15em, 100%), 1fr)); // Min is spelled with capital M to avoid sass' complaining about incompatible units due it's own internal min function
-        column-gap: 2em;
-        row-gap: 2em;
+        grid-template-columns: repeat(auto-fill, minmax(Min(260px, 100%), 1fr)); // Min is spelled with capital M to avoid sass' complaining about incompatible units due it's own internal min function
+        column-gap: 1em;
+        row-gap: 1em;
     }
     
     .partner {
-        text-align: center;
-        padding: 1em;
         text-align: center;
 
         a {
@@ -30,54 +28,32 @@
             flex-direction: row;
             flex-wrap: nowrap;
             align-items: center;
+            padding: 1em;
+
+            &:hover, &:active, &:focus {
+                text-decoration: underline;
+                color: $core;
+            }
         }
 
         & + .partner {
-        border-top: 1px solid $line;
+            // adds a border between partners on small screens
+            @include respond-max(579px) {
+                border-top: 1px solid $line;
+            }
         }
         
-
         img {
             width: 80px;
             height: auto;
             margin-right: 1em;
         }
 
-        .partner-name {
-            display: inline-block;
-
-            &::after {
-                content: "";
-                display: block;
-                position: relative;
-                height: 1px;
-                background-color: $attention;
-                width: 0%;
-                bottom: 0;
-                left: 0;
-                transition: all .125s ease-out;
-
-                @include respond-min(580px) {
-                    left: 50%;
-                    transform: translateX(-50%);
-                }
-            }
-        }
-
-        a:hover .partner-name::after, a:active .partner-name::after, a:focus .partner-name::after {
-            transition: all .125s ease-out;
-            width: 100%;
-
-            @include respond-min(580px) {
-                transform: translateX(-50%);
-            }
-        }
-
         @include respond-min(580px) {
-            @include box-shadow(5);
             border-radius: 8px;
-            border: 1px solid $line;
+            border: 2px solid $line;
             transition: all .125s ease-out;
+            border-top-width: 2px;
 
             a {
                 flex-direction: column;
@@ -89,7 +65,7 @@
             }
 
             &:hover, &:active, &:focus, &:focus-within {
-                @include box-shadow(15);
+                border-color: $core;
                 transition: all .125s ease-in;
             }
         }

--- a/_sass/_partners.scss
+++ b/_sass/_partners.scss
@@ -1,0 +1,97 @@
+.partners-page main.container {
+    padding: 0 1em;
+
+    @include respond-min(768px) {
+        margin: 0 auto;
+        max-width: 1400px;
+        padding: 0 (32/768) * 100%;
+    }
+}
+
+.partners {
+    margin-bottom: 2em;
+    transition: all .25s ease-out;
+
+    @include respond-min(580px) {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(Min(15em, 100%), 1fr)); // Min is spelled with capital M to avoid sass' complaining about incompatible units due it's own internal min function
+        column-gap: 2em;
+        row-gap: 2em;
+    }
+    
+    .partner {
+        text-align: center;
+        padding: 1em;
+        text-align: center;
+
+        a {
+            display:flex;
+            text-decoration: none;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            align-items: center;
+        }
+
+        & + .partner {
+        border-top: 1px solid $line;
+        }
+        
+
+        img {
+            width: 80px;
+            height: auto;
+            margin-right: 1em;
+        }
+
+        .partner-name {
+            display: inline-block;
+
+            &::after {
+                content: "";
+                display: block;
+                position: relative;
+                height: 1px;
+                background-color: $attention;
+                width: 0%;
+                bottom: 0;
+                left: 0;
+                transition: all .125s ease-out;
+
+                @include respond-min(580px) {
+                    left: 50%;
+                    transform: translateX(-50%);
+                }
+            }
+        }
+
+        a:hover .partner-name::after, a:active .partner-name::after, a:focus .partner-name::after {
+            transition: all .125s ease-out;
+            width: 100%;
+
+            @include respond-min(580px) {
+                transform: translateX(-50%);
+            }
+        }
+
+        @include respond-min(580px) {
+            @include box-shadow(5);
+            border-radius: 8px;
+            border: 1px solid $line;
+            transition: all .125s ease-out;
+
+            a {
+                flex-direction: column;
+            }
+
+            img {
+                margin-right: 0;
+                margin-bottom: .25em;
+            }
+
+            &:hover, &:active, &:focus, &:focus-within {
+                @include box-shadow(15);
+                transition: all .125s ease-in;
+            }
+        }
+    }
+}

--- a/_sass/_utils.scss
+++ b/_sass/_utils.scss
@@ -164,6 +164,12 @@ html {
 
 }
 
+
+// Generic box shadow generator TODO: Revise this with better math
+@mixin box-shadow ( $height: 10 ) {
+    box-shadow: rgba(0, 0, 0, 0.1) 0px ($height * 2+px) ($height * 2.5+px) (-$height / 2+px), rgba(0, 0, 0, 0.04) 0px ($height * 1+px) ($height * 1+px) (-$height / 2+px);
+}
+
 // Secondary content box-shadow:
 @mixin secondary-shadow-top {
     -moz-box-shadow: 0 4px 8px adjust-color($accent-dark, $alpha: 0.07);

--- a/_sass/_utils.scss
+++ b/_sass/_utils.scss
@@ -69,6 +69,12 @@ $font-path: "../fonts/fira-mono";
     }
 }
 
+@mixin respond-max($width) {
+    @media screen and (max-width: $width) {
+        @content;
+    }
+}
+
 @mixin device-min($width) {
     @media screen and (min-device-width: $width) {
         @content;

--- a/_sass/_utils.scss
+++ b/_sass/_utils.scss
@@ -170,12 +170,6 @@ html {
 
 }
 
-
-// Generic box shadow generator TODO: Revise this with better math
-@mixin box-shadow ( $height: 10 ) {
-    box-shadow: rgba(0, 0, 0, 0.1) 0px ($height * 2+px) ($height * 2.5+px) (-$height / 2+px), rgba(0, 0, 0, 0.04) 0px ($height * 1+px) ($height * 1+px) (-$height / 2+px);
-}
-
 // Secondary content box-shadow:
 @mixin secondary-shadow-top {
     -moz-box-shadow: 0 4px 8px adjust-color($accent-dark, $alpha: 0.07);

--- a/assets/css/output.scss
+++ b/assets/css/output.scss
@@ -7,4 +7,5 @@
 @import "style"; // mobile & desktop styles
 @import "pygments"; // code highlighting
 @import "print"; // print styles
-@import "opensearch"
+@import "opensearch";
+@import "partners"

--- a/partners/index.html
+++ b/partners/index.html
@@ -2,14 +2,18 @@
 layout: fullwidth
 title: Partners
 primary_title: Partners
+body_class: partners-page
 ---
 
-OpenSearch is a team effort, we are grateful to all our partners.
+<p>OpenSearch is a team effort, we are grateful to all our partners.</p>
 
-<div id="partners">
+<div class="partners">
   {% for partner in site.partners %}
   <div class="partner">
-      <a href="{{ partner.link }}"><img src="{{ partner.logo }}" alt="{{ partner.name }} Logo" /><br /> {{ partner.name }}</a>
+    <a href="{{ partner.link }}" target="_blank">
+      <img src="{{ partner.logo }}" alt="{{ partner.name }} Logo" />
+      <span class="partner-name"> {{ partner.name }} </span>
+    </a>
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
### Description
These are mainly cosmetic CSS and markup changes to the partners page. I'm keeping the information and hierarchy the same, just adding some visual polish + responsive styles.
 
### Before
<img width="1680" alt="Screen Shot 2021-06-22 at 3 13 19 PM" src="https://user-images.githubusercontent.com/3443142/123006528-a8fcca80-d36c-11eb-8262-8b688eeaf006.png">

### After
<img width="1680" alt="Screen Shot 2021-06-22 at 3 12 30 PM" src="https://user-images.githubusercontent.com/3443142/123006540-aef2ab80-d36c-11eb-91e3-6762cfc2856a.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
