### PR TITLE
Add title, url, site name and image opengraph tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,14 @@
     <meta name="keywords" content="open-source, search, opensearch" />
     <meta name="description" content="{{ page.description}}" />
 
+    <meta content="{{ site.title }}" property="og:site_name">
+    <meta content="{{ page.url | absolute_url }}" property="og:url">
+    {% if page.title %}<meta content="{{ page.title }}" property="og:title">
+    {% else %}<meta content="{{ site.title }}" property="og:title"> {% endif %}
+
+    {% if page.image %}<meta content="{{ site.url }}/assets/img/posts/{{ page.image }}" property="og:image">
+    {% else %}<meta content="{{ site.url }}/assets/img/logo-high-resolution.png" property="og:image">{% endif %}
+
     {{ page.link_rel_tags }}
     <!-- Favicons -->
     <link rel="apple-touch-icon" href="{{'assets/img/icon-touch.png' | relative_url }}">


### PR DESCRIPTION
Signed-off-by: Lorna Mitchell <lornajane@aiven.io>

### Description
Adds a few opengraph tags to `head.html`, doesn't include description since it doesn't seem to be set but if there is a description that should be used, I can add that too.
 
### Issues Resolved
 Fixes #132


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
