### PR TITLE
fixing sig link on arm64

### DIFF
--- a/_artifacts/opensearch-1.0.0/arm64/opensearch-1.0.0-min-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.0.0/arm64/opensearch-1.0.0-min-linux-arm64.markdown
@@ -9,7 +9,7 @@ category: opensearch
 type: targz
 
 artifact_url: https://artifacts.opensearch.org/releases/core/opensearch/1.0.0/opensearch-min-1.0.0-linux-arm64.tar.gz
-signature: https://artifacts.opensearch.org/releases/core/opensearch/1.0.0/opensearch-min-1.0.0-linux-arm64.tar.gz
+signature: https://artifacts.opensearch.org/releases/core/opensearch/1.0.0/opensearch-min-1.0.0-linux-arm64.tar.gz.sig
 security_warning: true
 indirect: true
 ---


### PR DESCRIPTION
### Description
makes signature link for opensearch-min download actual signature, not full tarball
 


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
