### PR TITLE
Fixes typo on Downloads page

### DIFF
--- a/_includes/downloads/opensearch-docker.markdown
+++ b/_includes/downloads/opensearch-docker.markdown
@@ -2,6 +2,6 @@ The best way to try out OpenSearch is to use [Docker Compose](https://docs.docke
 
 1. Download [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) into your desired directory
 2. Run `docker-compose up`
-3. Have a nice coffee while everything is downloading and startup up
+3. Have a nice coffee while everything is downloading and starting up
 4. Navigate to [http://localhost:5601/](http://localhost:5601) for OpenSearch Dashboards
 5. Login with the default username (`admin`) and password (`admin`)


### PR DESCRIPTION
### Description

Before:
`3. Have a nice coffee while everything is downloading and startup up`

After:
`3. Have a nice coffee while everything is downloading and starting up`

Signed-off-by: Tommy Markley <markleyt@amazon.com>
 
### Issues Resolved
https://github.com/opensearch-project/project-website/issues/201

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
