### PR TITLE
Updates to remove `staging` branch from content

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ If you need help and are unsure where to open an issue, try [forums](https://dis
 
 ## Contributing
 
-We welcome contributions! Please see our [CONTRIBUTING](CONTRIBUTING.md) page to learn more about how to contribute to the website.
+We welcome contributions! Please see our [CONTRIBUTING](CONTRIBUTING.md) page to learn more about how to contribute to the website. 
+
+_Note:_ As of July 20, 2021, contributions are welcome on the `main` branch; the `prod` branch is now protected and holds the finalized version of the site. The `staging` branch has been removed and is no longer being used.
 
 ### Adding to the Partners Page
 

--- a/community_projects/index.html
+++ b/community_projects/index.html
@@ -6,7 +6,7 @@ body_class: community_projects-page
 ---
 
 <p>This page was made to highlight projects built by the community for the community.</p>
-<p> Want your project on this page? To add your project to this page, please create a fork the <a href="https://github.com/opensearch-project/project-website" target="_blank" rel="noopener noreferrer">project website</a>, add a markdown file for your project under <b>/_community_projects/your-project.md</b> , and submit a pull request to our <b>`staging`</b> branch.</p>
+<p> Want your project on this page? To add your project to this page, please create a fork the <a href="https://github.com/opensearch-project/project-website" target="_blank" rel="noopener noreferrer">project website</a>, add a markdown file for your project under <b>/_community_projects/your-project.md</b> , and submit a pull request.</p>
 
 <h2>Projects</h2>
 <section class="community_projects">


### PR DESCRIPTION
### Description
🥳 `staging` is going away. `main` is the new working branch and `prod` = opensearch.org
 
### Issues Resolved
#57

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
