### PR TITLE
added 4gb warning to docker compose instructions

### DIFF
--- a/_includes/downloads/opensearch-docker.markdown
+++ b/_includes/downloads/opensearch-docker.markdown
@@ -1,7 +1,8 @@
 The best way to try out OpenSearch is to use [Docker Compose](https://docs.docker.com/compose/install/). These steps will setup a two node cluster of OpenSearch plus OpenSearch Dashboards:
 
 1. Download [docker-compose.yml](https://opensearch.org/samples/docker-compose.yml) into your desired directory
-2. Run `docker-compose up`
-3. Have a nice coffee while everything is downloading and starting up
-4. Navigate to [http://localhost:5601/](http://localhost:5601) for OpenSearch Dashboards
-5. Login with the default username (`admin`) and password (`admin`)
+2. Make sure you have Docker set to use at least 4 GB of RAM in **Preferences** > **Resources**.
+3. Run `docker-compose up`
+4. Have a nice coffee while everything is downloading and starting up
+5. Navigate to [http://localhost:5601/](http://localhost:5601) for OpenSearch Dashboards
+6. Login with the default username (`admin`) and password (`admin`)


### PR DESCRIPTION
### Description
Adds instruction to set docker to use a larger amount of ram for the example
 
### Issues Resolved
#222

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
