### PR TITLE
Fix urls on `/authors` and `/versions`

### DIFF
--- a/authors/index.html
+++ b/authors/index.html
@@ -6,6 +6,6 @@ primary_title: Authors
 
 <ul>
   {% for author in site.authors %}
-    <li><a href="{{ author.url }}">{{ author.name }}</a></li>
+    <li><a href="{{ author.url }}.html">{{ author.name }}</a></li>
   {% endfor %}
 </ul>

--- a/versions/index.html
+++ b/versions/index.html
@@ -4,7 +4,7 @@ layout: fullwidth
 <ul>
   {% assign versions = site.versions | sort: 'date' | reverse %}
   {% for version in versions %}
-    <li><a href="{{ version.url }}">
+    <li><a href="{{ version.url }}.html">
       {% if version.product == 'odfe' %} Open Distro for Elasticsearch {% else %} OpenSearch {%endif%} {{ version.version }}</a>
     </li>
   {% endfor %}


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
URLs on [versions](https://opensearch.org/versions/) and [authors](https://opensearch.org/authors/) pages are missing the `.html` suffix; this change fixes them.
 
### Issues Resolved
[List any issues this PR will resolve]


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
