### PR TITLE
Sitemap index to include documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,9 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - node_modules
-  
+  - bower.json
+  - package.json
+
 defaults:
 -
     scope:
@@ -73,7 +75,6 @@ collections:
     output: true
   versions:
     output: true
-  partners:
   faqs:
     
 paginate: 5
@@ -100,6 +101,3 @@ paginate_path: "/blog/page:num/"
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
-exclude:
-  - bower.json
-  - package.json

--- a/robots.txt
+++ b/robots.txt
@@ -2,4 +2,5 @@
 layout: none
 ---
 User-agent: *
-Sitemap: {{ site.url }}/sitemap.xml
+Disallow: /docs/javadoc/
+Sitemap: {{ site.url }}/sitemap-index.xml

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -1,0 +1,12 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>{{ site.url }}/sitemap.xml</loc>
+    </sitemap>
+    <sitemap>
+        <loc>{{ site.url }}/docs/sitemap.xml</loc>
+    </sitemap>
+</sitemapindex>


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
Generates a sitemap-index to point to the website sitemap, as well as the docs sitemap. The sitemap-index is then fed to `robots.txt` instead of the website sitemap.

PS, in the process, I merged the 2 `exclude` directives in the config.
 
### Issues Resolved
[List any issues this PR will resolve]


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
