### PR TITLE
Remove extra `.html` from versions and artifacts

### DIFF
--- a/_layouts/versions.html
+++ b/_layouts/versions.html
@@ -189,7 +189,7 @@ this is the built-in error checking for the version definition having missing ar
             {% if details.artifact_url %}
 
               {% capture artifact_extra %}<div class="extra_links extra_{{artifact_id}}"> 
-                <a href="{% if details.indirect %}{{details.url | append: '.html' }}{% else %}{{details.artifact_url}}{% endif %}" 
+                <a href="{% if details.indirect %}{{details.url}}{% else %}{{details.artifact_url}}{% endif %}"
                 class="cta">Download</a> </div>{% endcapture %}
               {% assign artifact_extras = artifact_extras | append: artifact_extra %}
             {% endif %}

--- a/artifacts/index.html
+++ b/artifacts/index.html
@@ -20,7 +20,7 @@ primary_title: Artifacts
                     <li><a href="{{ artifact.link }}">{{ artifact.link }}</a> [External]</li>
                   {% else %}
                  
-                    <li><a href=" {% if artifact.indirect %}{{artifact.url | append: '.html' }}{% else %}{{artifact.artifact_url}}{% endif %}">{{ artifact.artifact_url | split: "/" | last }}</a></li>
+                    <li><a href=" {% if artifact.indirect %}{{artifact.url}}{% else %}{{artifact.artifact_url}}{% endif %}">{{ artifact.artifact_url | split: "/" | last }}</a></li>
                   {% endif %}
                 {% endfor %}
               </ul> 


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
This fixes extra `.html`s from URLs on the artifact and download pages for OpenSearch Minimum.
 
### Issues Resolved
[List any issues this PR will resolve]


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
