### PR TITLE
Organize javadocs landing pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ defaults:
       type: javadocs
     values:
       layout: javadocs
-      permalink: /docs/:collection/:name
+      permalink: /:collection/:name.html
 -
     scope:
       type: events

--- a/_javadocs/1.0.0.markdown
+++ b/_javadocs/1.0.0.markdown
@@ -1,5 +1,5 @@
 ---
-primary_title: Docs
+primary_title: JavaDocs
 title: '1.0.0 JavaDocs'
 javadocs:
   - OpenSearch/benchmarks/build/docs/javadoc/allclasses-index.html

--- a/_javadocs/beta-1.markdown
+++ b/_javadocs/beta-1.markdown
@@ -1,5 +1,5 @@
 ---
-primary_title: Docs
+primary_title: JavaDocs
 title: 'beta-1 JavaDocs'
 javadocs:
   - OpenSearch/benchmarks/build/docs/javadoc/allclasses-index.html

--- a/_javadocs/rc-1.markdown
+++ b/_javadocs/rc-1.markdown
@@ -1,5 +1,5 @@
 ---
-primary_title: Docs
+primary_title: JavaDocs
 title: 'rc-1 JavaDocs'
 javadocs:
   - OpenSearch/benchmarks/build/docs/javadoc/allclasses-index.html

--- a/_layouts/javadocs.html
+++ b/_layouts/javadocs.html
@@ -1,5 +1,6 @@
 ---
 layout: fullwidth
+primary_title: JavaDocs
 ---
 <h2>{{page.title}}</h2>
 <ul>
@@ -8,8 +9,9 @@ layout: fullwidth
     {% assign fname = parts  | last %}
     {%if fname == 'index.html' %}
       {% assign url = line %}
-      <li><a href="/javadocs/{{ page.slug }}/{{ url }}"><pre>{{line | remove: "OpenSearch/" | remove: 
-        "/build/docs/javadoc/index.html" | replace: "/" ,":"}}</pre></a></li>
+      <li><a href="/javadocs/{{ page.slug }}/{{ url }}" class="javadoc">
+          {{line | remove: "OpenSearch/" | remove: "/build/docs/javadoc/index.html" | replace: "/" ,":"}}
+      </a></li>
     {%endif%}
     </li>
   {% endfor %}

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -14,6 +14,10 @@ Altered for OpenSearch by AWS
 */
 
 //------------------- Globals
+html {
+    background: $accent-dark;
+}
+
 body {
     @include serif;
     @include font-size(18);
@@ -198,6 +202,11 @@ tt {
 
 span.pre {
     @include monospace;
+}
+
+a.javadoc {
+    @include monospace;
+    font-size: 1.5rem;
 }
 
 a:hover, a:active, a:focus {

--- a/javadocs/index.html
+++ b/javadocs/index.html
@@ -1,13 +1,13 @@
 ---
 layout: fullwidth
+primary_title: JavaDocs
 ---
-<h2>JavaDocs</h2>
 <p>There is an ongoing <a href="https://github.com/opensearch-project/OpenSearch/issues/221">effort to improve OpenSearch JavaDocs</a>.</p>
 <p>Arranged by version:</p>
 <ul>
   {% for javadoc in site.javadocs %}
   <li>
-    <a href="{{ javadoc.url | append: ".html"}}">{{javadoc.title}}</a>
+    <a href="{{ javadoc.url}}">{{javadoc.title}}</a>
   </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
Moves JavaDocs landing pages out of `/docs` into `/javadocs` where the artifacts actually are.
Makes the landing pages look marginally better.
Also pulled in the `html` backgroud from documentation which will
1. avoid showing white space when content is too short for the screen (like javadocs landing page)
2. avoid showing white space above and below on over scrolls
 
### Issues Resolved
[List any issues this PR will resolve]


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
