### PR TITLE
Introduce `redirect_from` plugin and add to `downloads.html`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.2.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
+gem "jekyll-redirect-from", "~> 0.16"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       jekyll (>= 3.7, < 5.0)
       posix-spawn (~> 0.3.9)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
@@ -82,6 +84,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   jekyll-last-modified-at
   jekyll-paginate
+  jekyll-redirect-from (~> 0.16)
   jekyll-sitemap
   minima (~> 2.5)
   tzinfo (~> 1.2)

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ headings:
 
 # Build settings
 plugins:
+  - jekyll-redirect-from
   - jekyll-feed
   - jekyll-paginate
   - jekyll-last-modified-at

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ defaults:
       type: javadocs
     values:
       layout: javadocs
-      permalink: /docs/:collection/:name
+      permalink: /:collection/:name.html
 -
     scope:
       type: events

--- a/_javadocs/1.0.0.markdown
+++ b/_javadocs/1.0.0.markdown
@@ -1,5 +1,5 @@
 ---
-primary_title: Docs
+primary_title: JavaDocs
 title: '1.0.0 JavaDocs'
 javadocs:
   - OpenSearch/benchmarks/build/docs/javadoc/allclasses-index.html

--- a/_javadocs/beta-1.markdown
+++ b/_javadocs/beta-1.markdown
@@ -1,5 +1,5 @@
 ---
-primary_title: Docs
+primary_title: JavaDocs
 title: 'beta-1 JavaDocs'
 javadocs:
   - OpenSearch/benchmarks/build/docs/javadoc/allclasses-index.html

--- a/_javadocs/rc-1.markdown
+++ b/_javadocs/rc-1.markdown
@@ -1,5 +1,5 @@
 ---
-primary_title: Docs
+primary_title: JavaDocs
 title: 'rc-1 JavaDocs'
 javadocs:
   - OpenSearch/benchmarks/build/docs/javadoc/allclasses-index.html

--- a/_layouts/javadocs.html
+++ b/_layouts/javadocs.html
@@ -1,5 +1,6 @@
 ---
 layout: fullwidth
+primary_title: JavaDocs
 ---
 <h2>{{page.title}}</h2>
 <ul>
@@ -8,8 +9,9 @@ layout: fullwidth
     {% assign fname = parts  | last %}
     {%if fname == 'index.html' %}
       {% assign url = line %}
-      <li><a href="/javadocs/{{ page.slug }}/{{ url }}"><pre>{{line | remove: "OpenSearch/" | remove: 
-        "/build/docs/javadoc/index.html" | replace: "/" ,":"}}</pre></a></li>
+      <li><a href="/javadocs/{{ page.slug }}/{{ url }}" class="javadoc">
+          {{line | remove: "OpenSearch/" | remove: "/build/docs/javadoc/index.html" | replace: "/" ,":"}}
+      </a></li>
     {%endif%}
     </li>
   {% endfor %}

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -14,6 +14,10 @@ Altered for OpenSearch by AWS
 */
 
 //------------------- Globals
+html {
+    background: $accent-dark;
+}
+
 body {
     @include serif;
     @include font-size(18);
@@ -198,6 +202,11 @@ tt {
 
 span.pre {
     @include monospace;
+}
+
+a.javadoc {
+    @include monospace;
+    font-size: 1.5rem;
 }
 
 a:hover, a:active, a:focus {

--- a/downloads.html
+++ b/downloads.html
@@ -1,5 +1,9 @@
 ---
 foobar: one
+redirect_from:
+- /download/
+- /downloads/
+- /download.html
 ---
 {% assign version = site.versions | sort: date | last %}
 {{ version }}

--- a/javadocs/index.html
+++ b/javadocs/index.html
@@ -1,13 +1,13 @@
 ---
 layout: fullwidth
+primary_title: JavaDocs
 ---
-<h2>JavaDocs</h2>
 <p>There is an ongoing <a href="https://github.com/opensearch-project/OpenSearch/issues/221">effort to improve OpenSearch JavaDocs</a>.</p>
 <p>Arranged by version:</p>
 <ul>
   {% for javadoc in site.javadocs %}
   <li>
-    <a href="{{ javadoc.url | append: ".html"}}">{{javadoc.title}}</a>
+    <a href="{{ javadoc.url}}">{{javadoc.title}}</a>
   </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
### Description
Introduces `redirect_from` plugin and add to `downloads.html`. This will gracefully handle typos in incoming URLs like `/downloads` or `/download.html` when in fact the visitor wanted `/downloads.html`.
 
### Issues Resolved
[List any issues this PR will resolve]


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
