### PR TITLE
fixed copyright due to BSD not having notice file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ This website was forked from the BSD-licensed [djangoproject.com](https://github
 
 ## Copyright
 
-Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.
+Copyright OpenSearch Contributors. 


### PR DESCRIPTION
### Description
Tweaked copyright message on README because of NOTICE file link being missing (ALv2 vs BSD-3 differences accounted for)

### Issues Resolved
#252 

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
