### PR TITLE
Improve the listing of past events

### DIFF
--- a/events/past.html
+++ b/events/past.html
@@ -13,7 +13,8 @@ body_class: events-page
 <h2>Past</h2>
 
 <ul class="list-events">
-  {% for event in  past_events  %}
+  {% assign sorted_events = past_events | sort: "eventdate" | reverse %}
+  {% for event in sorted_events %}
     {% include event.html %}
   {% endfor %}  
 </ul>

--- a/events/past.html
+++ b/events/past.html
@@ -6,14 +6,14 @@ body_class: events-page
 ---
 
 {% assign now =  site.time |  date_to_xmlschema %}
-{% assign future_events = site.events | where_exp: "event","event.eventdate  < now" %}
+{% assign past_events = site.events | where_exp: "event","event.eventdate  < now" %}
 {% assign primary_title = site.headings.events %}
 {% assign layout_class = 'sidebar-right events-page' %}
 
 <h2>Past</h2>
 
 <ul class="list-events">
-  {% for event in  future_events  %}
+  {% for event in  past_events  %}
     {% include event.html %}
   {% endfor %}  
 </ul>


### PR DESCRIPTION
### Description

The past events page does not sort them, making it difficult to locate a precise item (e.g. the last event to access the corresponding collaborative agenda on HackMD).

These changes sort the past events in reverse choronological order.
 
### Issues Resolved

n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
