### PR TITLE
changed how pinned repos are stored

### DIFF
--- a/_data/repos.yml
+++ b/_data/repos.yml
@@ -1,4 +1,12 @@
 -
+    shortname: org
+    pinned: true
+    categories: 
+    - core
+    title: OpenSearch Project Org
+    description: The GitHub organization for the entire OpenSearch Project
+    url: https://github.com/opensearch-project
+-
     shortname: os
     categories: 
       - core

--- a/_layouts/source.html
+++ b/_layouts/source.html
@@ -7,12 +7,14 @@ layout: default
 {% capture content %}
     {{ content }}
     <dl class="pinned-repos">
-    {% for repo in page.pinned_repos %}
+    {% assign pinned =  site.data.repos | where_exp:"repo", "repo.pinned == true" %}
+    {% for repo in pinned %}
         {%- include repo.html repo=repo %}
     {% endfor %}
     </dl>
     <dl class="repos">
-    {% for repo in site.data.repos %}
+    {% assign unpinned =  site.data.repos | where_exp:"repo", "repo.pinned != true" %}
+    {% for repo in unpinned %}
         {%- include repo.html repo=repo %}
     {% endfor %}
     </dl>

--- a/source.markdown
+++ b/source.markdown
@@ -1,14 +1,6 @@
 ---
 layout: source
 body_class: source-page
-pinned_repos: 
-    -
-        shortname: org
-        categories: 
-        - core
-        title: OpenSearch Project Org
-        description: The GitHub organization for the entire OpenSearch Project
-        url: https://github.com/opensearch-project
 ---
 
 OpenSearch and OpenSearch Dashboards as well as the plugins and tools included in the OpenSearch Project are open source software with an Apache 2.0 license. We encourage you to use it all to the full extent of this license. 


### PR DESCRIPTION
### Description
Move pinned repo entires back into site data to unbreak homepage


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
