### PR TITLE
OpenSIEM Community Partner Tile for Community Page

### DIFF
--- a/_community_projects/open-siem-logstash-parsing.md
+++ b/_community_projects/open-siem-logstash-parsing.md
@@ -1,0 +1,9 @@
+---
+name: OpenSIEM Logstash Parsing Configurations
+description: Logstash parsing for more than a hundred technologies. We welcome contributions for security and non-security based technologies.
+owner: Cargill, Inc.
+owner_link: https://github.com/Cargill
+link: https://github.com/Cargill/OpenSIEM-Logstash-Parsing
+license: Apache License 2.0
+license_link: https://github.com/Cargill/OpenSIEM-Logstash-Parsing/blob/master/LICENSE
+---


### PR DESCRIPTION
### Description
[Describe what this change achieves]

This will add Cargill's OpenSIEM repo as one of the tiles on the https://opensearch.org/community_projects/ pages.
 
### Issues Resolved
[List any issues this PR will resolve]
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
Yep
