### PR TITLE
Modify Diggie download URL

### DIFF
--- a/_community_projects/diggie.md
+++ b/_community_projects/diggie.md
@@ -4,7 +4,7 @@ description: Professional GUI client for AWS OpenSearch, desktop app of Mac / Wi
 owner: Serverless Operations, Inc.
 owner_link: https://serverless.co.jp
 link: https://github.com/DiggieApp/Diggie
-download_link: https://github.com/DiggieApp/Diggie/releases/tag/0.1.0
+download_link: https://github.com/DiggieApp/Diggie/releases
 license: Diggie EULA (developer preview)
 license_link: https://github.com/DiggieApp/Diggie/blob/master/license.txt
 # upload your logo to the following directory


### PR DESCRIPTION
### Description
Modified Diggie download URL because it is currently a version-specific URL. This leads viewers to our release page so they can find the latest version anytime.

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
