### PR TITLE
Added Data Prepper 1.1.0 as a new release

### DIFF
--- a/_artifacts/data-prepper/data-prepper-1.1.0-docker-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-1.1.0-docker-x64.markdown
@@ -1,0 +1,11 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-1.1.0
+platform: docker
+type: docker_hub
+architecture: x64
+link: https://hub.docker.com/r/opensearchproject/data-prepper/tags?page=1&ordering=last_updated&name=1.1.0
+slug: data-prepper-1.1.0-docker-x64
+category: opensearch
+---

--- a/_versions/2021-07-12-opensearch-1.0.0.markdown
+++ b/_versions/2021-07-12-opensearch-1.0.0.markdown
@@ -25,7 +25,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-1.0.0
+    version: data-prepper-1.1.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-09-01-opensearch-1.0.1.markdown
+++ b/_versions/2021-09-01-opensearch-1.0.1.markdown
@@ -25,7 +25,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-1.0.0
+    version: data-prepper-1.1.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-10-05-opensearch-1.1.0.markdown
+++ b/_versions/2021-10-05-opensearch-1.1.0.markdown
@@ -25,7 +25,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-1.0.0
+    version: data-prepper-1.1.0
   -
     role: minimal-artifacts
     artifact: opensearch-min


### PR DESCRIPTION
### Description

This PR uses Data Prepper 1.1.0 instead of 1.0.0. It has updates for OpenSearch 1.1.0, 1.0.1, and 1.0.0.
 
### Issues Resolved

None


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
