### PR TITLE
Sort Javadocs versions

### DIFF
--- a/javadocs/index.html
+++ b/javadocs/index.html
@@ -4,10 +4,32 @@ primary_title: JavaDocs
 ---
 <p>There is an ongoing <a href="https://github.com/opensearch-project/OpenSearch/issues/221">effort to improve OpenSearch JavaDocs</a>.</p>
 <p>Arranged by version:</p>
-<ul>
-  {% for javadoc in site.javadocs %}
-  <li>
-    <a href="{{ javadoc.url}}">{{javadoc.title}}</a>
-  </li>
-  {% endfor %}
-</ul>
+<ul id="javadoc-versions"></ul>
+<script>
+  const elVersions = document.getElementById('javadoc-versions');
+  const versions = [
+    {% for javadoc in site.javadocs %}
+      {title: '{{javadoc.title}}', url: '{{ javadoc.url}}'},
+    {% endfor %}
+  ].map(v => ({
+    ...v,
+    sortKey: `${/^\d/.test(v.title) ? '' : '0-'}${v.title}`
+      .replace(/\s*JavaDocs.*$/i, '')
+      .replace(/\.*([^0-9\.-]+)/g, '.$1')
+      .split(/[\.-]+/)
+      .flatMap(part => isNaN(part) ? ['-', part.padStart('0', 3)] : part.padStart('0', 3))
+      .join('.')
+      .toLowerCase()
+  })).sort((b, a) => a.sortKey.localeCompare(b.sortKey));
+  const frag = document.createDocumentFragment();
+  versions.forEach(v => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.textContent = v.title;
+    a.href = v.url;
+    li.appendChild(a);
+    frag.appendChild(li);
+  });
+  while (elVersions.firstChild) elVersions.removeChild(elVersions.firstChild);
+  elVersions.appendChild(frag);
+</script>


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
The existing logic on the Javadocs landing page doesn't sort the list of versions. Moreover, complex sorting of semantic versions is beyond what Liquid can do. This commit delegates the task to JS.
 
### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
