### PR TITLE
Add Opensearch-dashboards plugin to Community projects page

### DIFF
--- a/_community_projects/transform-plugin.md
+++ b/_community_projects/transform-plugin.md
@@ -1,6 +1,6 @@
 ---
-name: Transform plugin for Opensearch Dashboards
-description: An Opensearch Dashboards visualization plugin that allows arbitrary queries results to be processed by a Mustache transform. You can also call any external JS library to build new visualisations such as Google Chart, d3js, ...
+name: Transform plugin for OpenSearch Dashboards
+description: An OpenSearch Dashboards visualization plugin that allows arbitrary queries results to be processed by a Mustache transform. You can also call any external JS library to build new visualisations such as Google Chart, d3js, ...
 owner: Lionel Guillaud
 owner_link: https://github.com/lguillaud
 link: https://github.com/lguillaud/osd_transform_vis


### PR DESCRIPTION
### Description
Add Opensearch-dashboards plugin to Community projects page.
An Opensearch visualization plugin that allows arbitrary queries results to be processed by a Mustache transform. You can also call any external JS library to build new visualisations such as Google Chart, d3js, ...
 
### Issues Resolved
New plugin.


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
