### PR TITLE
Replace "Get Started" With "Download"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ headings:
   news: 'News'
   source: 'Source Code'
   authors: 'Authors'
-  downloads: 'Download & Get Started'
+  downloads: 'Download'
 
 
 # Build settings

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,7 +32,7 @@
         {%- include nav_item.html text="Source" href="/source.html" url_full="/source.html" url_fragment="source" -%}
         {%- include nav_item.html text="Documentation" href="/docs" url_full="/docs/" url_fragment="docs" -%}
         {%- include nav_item.html text="Events" href="/events/" url_full="/events/" url_fragment="events" -%}
-        {%- include nav_item.html text="Get Started" href="/downloads.html" url_full="/downloads.html" url_fragment="downloads" -%}
+        {%- include nav_item.html text="Download" href="/downloads.html" url_full="/downloads.html" url_fragment="downloads" -%}
       </ul>
     </div>
   </div>

--- a/index.markdown
+++ b/index.markdown
@@ -16,7 +16,7 @@ download_ctas:
 ctas:
     post: ' on GitHub'
     primary: 
-        text: 'Get Started'
+        text: 'Download'
         url: '/downloads.html'
     roadmap:
         text: 'View the project roadmap'


### PR DESCRIPTION
### Description
Changes the website navigation, home page, and header to say simply "Download" instead of "Get Started"
 
### Issues Resolved
#383

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
