### PR TITLE
[Fixed] external link opens to same tab

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -61,7 +61,7 @@ layout: default
 
       {% assign org = site.data.repos | find: "shortname", "org" %}
       {% if org.url %}
-      <a href="{{ org.url }}" class="cta outline">
+      <a href="{{ org.url }}" target="_blank" class="cta outline">
         {{page.ctas.pre}} {{ org.title }} {{page.ctas.post}}
       </a>
       {% endif %}


### PR DESCRIPTION
### Description
Fixed that bug by setting attribute target="_blank"
 
### Issues Resolved
[BUG] external link opens to same tab #481



By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
