### PR TITLE
Normalize timezone across builds

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,7 +92,7 @@ collections:
 paginate: 5
 paginate_path: "/blog/page:num/"
 
-
+timezone: "Etc/UTC"
 
 # Exclude from processing.
 # The following items will not be processed, by default.


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
* Without a timezone set in the config file, different environments can result in differing dates.
* With a non-UTC timezone set, unquoted date-time combinations can lead to dates being a day off.
* Using UTC, both the above problems are avoided.

Examples:
* `timezone: "America/Los_Angeles"` in config:
    * `date: 2021-11-15 01:01:01` results in "Sun, Nov 14, 2021"
    * `date: '2021-11-15 01:01:01'` results in "Mon, Nov 15, 2021"
    * `date: 2021-11-15` results in "Mon, Nov 15, 2021"
    * `date: '2021-11-15'` results in "Mon, Nov 15, 2021"
* `timezone: "Asia/Vladivostok"` in config:
    * `date: 2021-11-15 21:01:01` results in "Tue, Nov 16, 2021"
    * `date: '2021-11-15 21:01:01'` results in "Mon, Nov 15, 2021"
    * `date: 2021-11-15` results in "Mon, Nov 15, 2021"
    * `date: '2021-11-15'` results in "Mon, Nov 15, 2021"
* `timezone: "Etc/UTC"` in config:
    * `date: 2021-11-15 21:01:01` results in "Mon, Nov 15, 2021"
    * `date: '2021-11-15 21:01:01'` results in "Mon, Nov 15, 2021"
    * `date: 2021-11-15` results in "Mon, Nov 15, 2021"
    * `date: '2021-11-15'` results in "Mon, Nov 15, 2021"
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
