### PR TITLE
Add custom search indexing and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ This site uses [Jekyll](https://jekyllrb.com/). You can build the site and make 
 
 Alternatively, build the site with `bundle exec jekyll build`. The HTML output is generated into `/_site`. For the full configuration options when running Jekyll, see [this page](https://jekyllrb.com/docs/configuration/options/).
 
+### Search Bar Invisible Pages
+
+To prevent a document from appearing in search results, you can add `omit_from_search: true` to its front matter.
+
+
 ### Testing
 
 #### Link checker

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,6 @@ twitter_username:
 github_username: 
 headings:
   news: 'News'
-  source: 'Source Code'
   authors: 'Authors'
   downloads: 'Download & Get Started'
 

--- a/_includes/copy_banner.html
+++ b/_includes/copy_banner.html
@@ -3,6 +3,22 @@
         {{ header }}
         {% assign primary_title = page.primary_title | default: primary_title | default: '' %}
         {% if primary_title.size > 0 %}<h1><a href="#">{{primary_title}}</a></h1>{% endif %}
+
+        <div class="search">
+            <div class="search-input-wrap">
+                <input type="text" id="search-input" class="search-input"
+                       tabindex="0" placeholder="Search..." aria-label="Search {{ site.title }}"
+                       data-docs-version="latest" autocomplete="off">
+                <div class="search-spinner"><i></i></div>
+                <label for="search-input" class="search-label">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="search-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search">
+                        <circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                    </svg>
+                </label>
+            </div>
+            <div id="search-results" class="search-results custom-search-results"></div>
+        </div>
     </div>
+    <div class="search-overlay"></div>
 </div>
 <div id="billboard">{{ page.billboard }}</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,6 +39,7 @@
     };
     </script>
     <script data-main="{{ 'assets/js/main.js' | relative_url }}" src="{{'assets/js/lib/require.js' | relative_url }}"></script>
+    <script src="{{'assets/js/search.js' | relative_url }}"></script>
     {{ page.body_extra }}
 
   </body>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -13,10 +13,9 @@ layout: default
       <a href="" class="cta">get started</a>
   </p>
   {% endcomment %}
-{% endcapture %} 
-{% comment%}
+{% endcapture %}
+
 {% include copy_banner.html %}
-{% endcomment %}
 
 
 {% capture content %}

--- a/_plugins/search-indexer.rb
+++ b/_plugins/search-indexer.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "jekyll/hooks"
+require "jekyll/document"
+require "json"
+
+##
+# This singleton facilitates production of an indexable JSON representation of the content to populate a data source
+# to provide search functionality.
+
+module Jekyll::ContentIndexer
+
+  ##
+  # The collection that will get stores as the output
+
+  @data = []
+
+  ##
+  # Pattern to identify documents that should be excluded based on their URL
+
+  @excluded_paths = /(^\/blog\/(page\d|$)|^\/events\/([^\d]|$)|^\/faqs|\.(css|js|json|map|xml|txt|yml)$)/i.freeze
+
+  ##
+  # Pattern to identify block HTML tags (not comprehensive)
+
+  @html_block_tags = /\s*<[?\/]?(article|blockquote|d[dlt]|div|fieldset|form|h|li|main|nav|[ou]l|p|section|table|t[rd]).*?>\s*/im.freeze
+
+  ##
+  # Pattern to identify certain HTML tags whose content should be excluded from indexing
+
+  @html_excluded_tags = /\s*<(head|style|script|h1).*?>.*?<\/\1>/im.freeze
+
+  ##
+  # Initializes the singleton by recording the site
+
+  def self.init(site)
+    @site = site
+  end
+
+  ##
+  # Processes a Document or Page and adds it to the collection
+
+  def self.add(page)
+    return if @excluded_paths.match(page.url)
+
+    content = page.content
+                  .gsub(@html_excluded_tags, ' ')             # Strip certain HTML blocks
+                  .gsub(@html_block_tags, "\n")               # Strip some block HTML tags, replacing with newline
+                  .gsub(/\s*<[?\/!]?[a-z]+.*?>\s*/im, ' ')    # Strip all remaining HTML tags
+                  .gsub(/\s*[\r\n]+\s*/, "\n")                # Clean line-breaks
+                  .gsub(/\s{2,}/, ' ')                        # Trim long spaces
+                  .gsub(/\s+([.:;,)!\]?])/, '\1')             # Remove spaces before some punctuations
+                  .strip                                      # Trim leading and tailing whitespaces
+
+    return if content.empty?
+
+    url = @site.config["baseurl"] + page.url
+    type = nil
+
+    if page.instance_of?(Jekyll::Document)
+      # Appropriately assign types based on collection
+      case page.collection&.label
+      when 'posts'
+        type = 'POSTS'
+      when 'authors'
+        type = 'AUTHORS'
+        url << '.html'    # Add .html to URLs of author pages to correct the url
+      when 'events'
+        type = 'EVENTS'
+      when 'versions'
+        type = 'DOWNLOADS'
+        url << '.html'    # Add .html to URLs of author pages to correct the url
+      end
+    end
+
+    # Produce keywords
+    keywords = []
+    keywords += page.data["categories"] unless page.data["categories"].nil? || page.data["categories"]&.empty?
+    keywords += page.data["keywords"] unless page.data["keywords"].nil? || page.data["keywords"]&.empty?
+
+    data = {
+      url: url,
+      title: page.data["title"],
+      content: content,
+      keywords: keywords,
+      type: type
+    }
+
+    @data.push(data)
+  end
+
+  ##
+  # Saves the collection as a JSON file
+
+  def self.save
+    File.open(File.join(@site.config["destination"], "search-index.json"), 'w') do |f|
+      f.puts JSON.pretty_generate(@data)
+    end
+  end
+end
+
+# Before any Document or Page is processed, initialize the ContentIndexer
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  Jekyll::ContentIndexer.init(site)
+end
+
+# Process a Page as soon as its content is ready
+
+Jekyll::Hooks.register :pages, :post_convert do |page|
+  Jekyll::ContentIndexer.add(page)
+end
+
+# Process a Document as soon as its content is ready
+
+Jekyll::Hooks.register :documents, :post_convert do |document|
+  Jekyll::ContentIndexer.add(document)
+end
+
+# Save the produced collection after Jekyll is done writing all its stuff
+
+Jekyll::Hooks.register :site, :post_write do |_|
+  Jekyll::ContentIndexer.save()
+end

--- a/_sass/_custom-search.scss
+++ b/_sass/_custom-search.scss
@@ -1,0 +1,120 @@
+/*!
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * The OpenSearch Contributors require contributions made to this file be licensed
+ * under the BSD-3-Clause license or a compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*! just-the-docs
+ *  Copyright (c) 2016 Patrick Marsceill
+ *  SPDX-License-Identifier: MIT
+ */
+
+.copy-banner {
+  a, h1 {
+    white-space: nowrap;
+  }
+}
+
+[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
+.search { position: relative; z-index: 2; flex-grow: 1; height: 6.4rem; padding: 0.8rem; transition: padding linear 200ms; box-sizing: border-box; }
+.search * { box-sizing: border-box; }
+@media (min-width: 46.25rem) { .search { position: relative !important; width: auto !important; height: 100% !important; padding: 0; transition: none; } }
+.search-input-wrap { position: relative; z-index: 1; height: 4.8rem; overflow: hidden; border-radius: 4px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08); transition: height linear 200ms; }
+@media (min-width: 46.25rem) { .search-input-wrap { position: absolute; width: 100%; max-width: 536px; height: 100% !important; border-radius: 0; box-shadow: none; transition: width ease 400ms; } }
+.search-input { position: absolute; width: 100%; height: 100%; padding-top: 0.8rem; padding-right: 1.6rem; padding-bottom: 0.8rem; padding-left: 4rem; font-size: 16px; background-color: #fff; border-top: 0; border-right: 0; border-bottom: 0; border-left: 0; border-radius: 0; }
+@media (min-width: 46.25rem) { .search-input { padding-top: 1.6rem; padding-bottom: 1.6rem; padding-left: 5.6rem; font-size: 14px; background-color: #FFFFFF; transition: padding-left linear 200ms; } }
+.search-input:focus { outline: 0; }
+.search-input:focus + .search-label .search-icon { color: #0055A6; }
+.search-label { position: absolute; display: flex; height: 100%; padding-left: 1.6rem; }
+@media (min-width: 46.25rem) { .search-label { padding-left: 3.2rem; transition: padding-left linear 200ms; } }
+.search-label .search-icon { width: 1.92rem; height: 1.92rem; align-self: center; color: #4D8399; }
+.search-results { position: absolute; left: 0; display: none; width: 100%; max-height: calc(100% - 6.4rem); overflow-y: auto; background-color: #fff; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08); }
+@media (min-width: 46.25rem) { .search-results { top: 100%; width: 536px; max-height: calc(100vh - 200%) !important; } }
+.search-results-list { padding-left: 0; margin-bottom: 0.4rem; list-style: none; font-size: 14px !important; }
+@media (min-width: 31.25rem) { .search-results-list { font-size: 16px !important; } }
+@media (min-width: 46.25rem) { .search-results-list { font-size: 12px !important; } }
+@media (min-width: 50rem) { .search-results-list { font-size: 14px !important; } }
+.search-results-list-item { padding: 0; margin: 0; }
+.search-result { display: block; padding-top: 0.4rem; padding-right: 1.2rem; padding-bottom: 0.4rem; padding-left: 1.2rem; }
+.search-result:hover, .search-result.active { background-color: #ebedf5; }
+.search-result-title { display: block; padding-top: 0.8rem; padding-bottom: 0.8rem; }
+@media (min-width: 31.25rem) { .search-result-title { display: inline-block; width: 40%; padding-right: 0.8rem; vertical-align: top; } }
+.search-result-doc { display: flex; align-items: center; word-wrap: break-word; }
+.search-result-doc.search-result-doc-parent { opacity: 0.5; font-size: 12px !important; }
+@media (min-width: 31.25rem) { .search-result-doc.search-result-doc-parent { font-size: 14px !important; } }
+@media (min-width: 46.25rem) { .search-result-doc.search-result-doc-parent { font-size: 11px !important; } }
+@media (min-width: 50rem) { .search-result-doc.search-result-doc-parent { font-size: 12px !important; } }
+.search-result-doc .search-result-icon { width: 1.6rem; height: 1.6rem; margin-right: 0.8rem; color: #0055A6; flex-shrink: 0; }
+.search-result-doc .search-result-doc-title { overflow: auto; }
+.search-result-section { margin-left: 2.4rem; word-wrap: break-word; }
+.search-result-rel-url { display: block; margin-left: 2.4rem; overflow: hidden; color: #959396; text-overflow: ellipsis; white-space: nowrap; font-size: 9px !important; }
+@media (min-width: 31.25rem) { .search-result-rel-url { font-size: 10px !important; } }
+.search-result-previews { display: block; padding-top: 0.8rem; padding-bottom: 0.8rem; padding-left: 1.6rem; margin-left: 0.8rem; color: #959396; word-wrap: break-word; border-left: 1px solid; border-left-color: #eeebee; font-size: 11px !important; }
+@media (min-width: 31.25rem) { .search-result-previews { font-size: 12px !important; } }
+@media (min-width: 31.25rem) { .search-result-previews { display: inline-block; width: 60%; padding-left: 0.8rem; margin-left: 0; vertical-align: top; } }
+.search-result-preview + .search-result-preview { margin-top: 0.4rem; }
+.search-result-highlight { font-weight: bold; }
+.search-no-result { padding-top: 0.8rem; padding-right: 1.2rem; padding-bottom: 0.8rem; padding-left: 1.2rem; font-size: 12px !important; }
+@media (min-width: 31.25rem) { .search-no-result { font-size: 14px !important; } }
+.search-button { position: fixed; right: 1.6rem; bottom: 1.6rem; display: flex; width: 5.6rem; height: 5.6rem; background-color: #fff; border: 1px solid rgba(0, 85, 166, 0.3); border-radius: 2.8rem; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08); align-items: center; justify-content: center; }
+.search-overlay { position: fixed; top: 0; left: 0; z-index: 1; width: 0; height: 0; background-color: rgba(0, 0, 0, 0.3); opacity: 0; transition: opacity ease 400ms, width 0s 400ms, height 0s 400ms; }
+.search-active .search { position: fixed; top: 0; left: 0; width: 100%; height: 100%; padding: 0; }
+.search-active .search-input-wrap { height: 6.4rem; border-radius: 0; }
+@media (min-width: 46.25rem) { .search-active .search-input-wrap { width: 536px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08); } }
+.search-active .search-input { background-color: #fff; }
+@media (min-width: 46.25rem) { .search-active .search-input { padding-left: 3.6799999999999997rem; } }
+@media (min-width: 46.25rem) { .search-active .search-label { padding-left: 0.96rem; } }
+.search-active .search-results { display: block; }
+.search-active .search-overlay { width: 100%; height: 100%; opacity: 1; transition: opacity ease 400ms, width 0s, height 0s; }
+@media (min-width: 46.25rem) { .search-active .main { position: fixed; right: 0; left: 0; } }
+.search-active .main-header { padding-top: 6.4rem; }
+@media (min-width: 46.25rem) { .search-active .main-header { padding-top: 0; } }
+.copy-banner .search { display: block; width: 100%; padding: 0; }
+@media (min-width: 46.25rem) { .copy-banner .search { display: block; height: 4.8rem !important; margin: 1.15rem 0 1.15rem 4.8rem; } }
+@media (min-width: 46.25rem) { .copy-banner .search-input-wrap { height: 4.8rem !important; right: 0; } }
+.search-active .main { position: relative !important; }
+@media (min-width: 46.25rem) { .search-active .search-results { right: 0; left: auto; max-height: calc(100vh - 200% - 60px) !important; } }
+#main-header.nav-open ~ .copy-banner .search { display: block; }
+.custom-search-results > div { padding: 1.6rem; }
+.custom-search-results cite { font-size: 12px; font-size: 1.2rem; font-family: "Open Sans", "Segoe UI", Tahoma, sans-serif; color: #002A3A; text-decoration: none; font-style: normal; display: block; line-height: 1; font-weight: normal; }
+
+.custom-search-results a {
+  font-size: 20px;
+  font-size: 2rem;
+  font-family: "Open Sans Condensed", Impact, "Franklin Gothic Bold", sans-serif;
+  line-height: 1.6;
+  font-weight: bold;
+
+  background: linear-gradient(rgb(238, 235, 238) 0%, rgb(238, 235, 238) 100%) repeat-x 0 100% / 1px 1px;
+  color: rgb(0, 85, 166);
+  font-size: 20px;
+  text-decoration: rgb(0, 85, 166);
+  -moz-osx-font-smoothing: grayscale;
+
+  &:hover {
+    background-image: linear-gradient(rgba(0, 85, 166, 0.45) 0%, rgba(0, 85, 166, 0.45) 100%);
+  }
+}
+
+.custom-search-results span { font-size: 14px; font-size: 1.4rem; color: #1B4859; line-height: 1.4; display: block; overflow-wrap: break-word; }
+.custom-search-results span:only-child { text-align: center; padding: 1.6rem; }
+.custom-search-results .highlighted { background: #EAF4F9; }
+.banner-alert ~ main .custom-search-results { max-height: calc(100vh - 200% - 60px - 5.76rem) !important; }
+.search-spinner { display: none; font-weight: 700; outline: 0; user-select: none; position: absolute; padding-left: 0.96rem; height: 100%; }
+.search-spinner.spinning { display: flex; }
+.search-spinner.spinning ~ .search-label { display: none; }
+.search-spinner > i { border-color: rgba(77, 131, 153, 0.2); position: relative; animation: spin 0.6s infinite linear; border-width: 3px; border-style: solid; border-radius: 100%; display: inline-block; width: 18px; height: 18px; vertical-align: middle; align-self: center; }
+.search-spinner > i:before { content: ""; border: 3px solid rgba(77, 131, 153, 0); border-top-color: rgba(77, 131, 153, 0.8); border-radius: 100%; display: block; left: -3px; position: absolute; top: -3px; height: 100%; width: 100%; box-sizing: content-box; }
+
+@keyframes spin {
+  from {
+    transform:rotate(0deg)
+  }
+  to {
+    transform:rotate(359deg)
+  }
+}

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -33,8 +33,8 @@ body {
     }
 
     // don't activate mobile styles for larger screens
-    @include respond-min(768px) {
-        min-width: 768px;
+    @include respond-min(46.25rem) {
+        min-width: 46.25rem;
     }
 }
 a {
@@ -105,7 +105,7 @@ h1 {
     color: $background-lightest;
     letter-spacing: -1px;
     line-height: 1.1;
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         @include font-size(32);
     }
 
@@ -137,7 +137,7 @@ h2 {
         }
 
         &:first-child {
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 margin-top: 20px;
             }
         }
@@ -166,7 +166,7 @@ h3 {
         margin-bottom: 5px;
 
         &:first-child {
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 margin-top: 12px;
             }
         }
@@ -258,7 +258,7 @@ blockquote {
     //Main column. Left aligned by default. See /styleguide for explanation.
     background: $background-lightest;
     padding: 1px 10px 40px;
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         min-height: 800px;
         border: 1px solid #ddd;
         float: right;
@@ -295,7 +295,7 @@ blockquote {
         padding: 0 10px 40px;
         width: auto;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             max-width: 740px;
             padding: 20px 0 40px;
             width: (704/768) * 100%;
@@ -338,7 +338,7 @@ blockquote {
     //Sidebar in column layouts, gray section in fullwidth layout
     padding: 0 10px 20px;
     @include font-size(15);
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         float: right;
         margin: 10px 0 20px 0;
         margin-right: 3%;
@@ -381,7 +381,7 @@ blockquote {
     margin: 0 10px;
     padding: 40px 0 60px;
 
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         .full-width & {
             max-width: 700px;
             margin: 0 auto;
@@ -404,7 +404,7 @@ blockquote {
     }
 }
 .container {
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         margin: 0 auto;
         max-width: 1400px;
         padding: 0 (32/768) * 100%;
@@ -423,7 +423,7 @@ blockquote {
 }
 .container--flex--wrap--mobile {
     flex-wrap: wrap;
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         flex-wrap: no-wrap;
     }
 }
@@ -442,7 +442,7 @@ blockquote {
     z-index: 0;
 
     .container {
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             position: relative;
         }
     }
@@ -490,7 +490,7 @@ blockquote {
             /*background: url(../img/opensearch-logo-monochrome.svg) center center no-repeat;*/
         }
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             margin-left: 0;
         }
     }
@@ -510,7 +510,7 @@ blockquote {
         text-decoration: none;
         width: 45px;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             display: none;
         }
 
@@ -534,7 +534,7 @@ blockquote {
         -webkit-transition: all 0.3s ease-out;
         transition: all 0.3s ease-out;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             // turn off animations if on a desktop width
             max-height: none;
 
@@ -552,7 +552,7 @@ blockquote {
 
         width: 100%;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             width: auto;
             float: right;
         }
@@ -561,7 +561,7 @@ blockquote {
             margin: 10px 0 0;
             padding: 0;
 
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 margin: 0;
             }
         }
@@ -576,7 +576,7 @@ blockquote {
             text-transform: uppercase;
             margin: 0 10px;
 
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 margin: 0;
                 border: 0;
                 float: left;
@@ -600,7 +600,7 @@ blockquote {
         }
 
         .nav-primary {
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 position: absolute;
                 right: 0;
                 top: 45px;
@@ -631,7 +631,7 @@ blockquote {
         top: 0;
         max-width: 660px;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             position: static;
         }
     }
@@ -641,7 +641,7 @@ blockquote {
     background: $background-darkest;
     padding: 1px 10px;
 
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         padding: 1px 0;
     }
 
@@ -660,7 +660,7 @@ blockquote {
             color: white;
         }
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             @include font-size(32);
 
             margin: .35em 0 .35em;
@@ -713,10 +713,6 @@ blockquote {
     }
 
     .homepage & {
-        padding: 50px 0;
-        background: white;
-        text-align: center;
-        border-bottom: 1px solid $line;
         p {
             max-width: 700px;
             margin-left: auto;
@@ -741,8 +737,19 @@ blockquote {
             color: white;
             border: 0;
         }
+    }
 
+    .container {
+        display: flex;
+        flex-flow: column nowrap;
+        align-items: flex-start;
+    }
 
+    @media (min-width: 46.25rem) {
+        .container {
+            flex-direction: row;
+            align-items: center;
+        }
     }
 }
 
@@ -781,7 +788,7 @@ blockquote {
         }
     }
 
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         dt {
             float: left;
             width: 31%;
@@ -811,7 +818,7 @@ blockquote {
         @include clearfix;
         padding: 0 10px;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             padding: 0;
         }
 
@@ -821,7 +828,7 @@ blockquote {
                     border-top: 0;
                 }
             }
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 float: left;
                 margin-bottom: -999px;
                 padding: 0 3% 999px 0;
@@ -847,7 +854,7 @@ blockquote {
         font-weight: 700;
         margin-top: 20px;
         padding: 30px 0 10px;
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             border: none;
             margin-top: 0;
         }
@@ -896,7 +903,7 @@ blockquote {
             float: left;
             @include font-size(12);
             margin: 20px 0 0 10px;
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 max-width: 80%;
                 padding-top: 30px;
                 margin: 0;
@@ -926,7 +933,7 @@ blockquote {
         text-decoration: none;
         text-indent: 100%;
         width: 142px;
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             float: left;
             margin: 20px 90px 0 0;
         }
@@ -943,7 +950,7 @@ blockquote {
         color: $attention-dark;
         margin: 0;
         padding: 0;
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             border: none;
         }
 
@@ -953,7 +960,7 @@ blockquote {
             padding: 17px 10px 11px;
             display: block;
             clear: both;
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 background: none;
                 float: left;
                 clear: none;
@@ -998,7 +1005,7 @@ blockquote {
             overflow: hidden;
             text-indent: -200px;
             width: 94px;
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 clear: both;
                 margin-top: 5px;
             }
@@ -1041,7 +1048,7 @@ blockquote {
     padding: 10px 0;
     text-align: center;
     text-transform: uppercase;
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         display: none;
     }
 }
@@ -1061,7 +1068,7 @@ blockquote {
     padding: 1em 1.5em;
     text-align: center;
     text-decoration: none;
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         margin: 20px auto;
         max-width: 400px;
     }
@@ -1085,7 +1092,7 @@ blockquote {
         + .link-readmore {
             display: block;
             text-align: center;
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 margin-top: -10px;
             }
         }
@@ -1171,7 +1178,7 @@ blockquote {
     //two column layout module
     margin: 20px 0;
 
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         @include clearfix;
         margin: 0;
         .col {
@@ -1227,7 +1234,7 @@ blockquote {
     }
 }
 .callout-right {
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         float: right;
         margin: 26px 0 0 35px;
         width: 33%;
@@ -1243,7 +1250,7 @@ blockquote {
     }
 }
 .callout-left {
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         float: left;
         margin: 26px 35px 0 0;
         width: 33%;
@@ -1511,7 +1518,7 @@ blockquote {
         float: left;
         margin: 10px 5% 0 0;
         width: 45%;
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             margin-right: 3%;
             width: 30%;
         }
@@ -1551,7 +1558,7 @@ dl.list-features {
         padding: 0;
     }
 
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         padding-bottom: 40px;
 
         dt {
@@ -1716,7 +1723,7 @@ dl.list-features {
                 }
             }
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
 
             dt {
                 padding: 20px 0 0px 0;
@@ -1746,7 +1753,7 @@ dl.list-features {
     }
 }
 
-@include respond-min(768px) {
+@include respond-min(46.25rem) {
 
     .list-collapsing-header {
         float: left;
@@ -1852,7 +1859,7 @@ dl.list-features {
         border-top: 1px solid $line;
         margin-top: 20px;
         padding-top: 40px;
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             @include clearfix;
             margin-top: 20px;
             padding-top: 40px;
@@ -1884,7 +1891,7 @@ dl.list-features {
         max-width: 100%;
     }
 
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         img {
             float: left;
             margin: 0 40px 0 0;
@@ -2193,9 +2200,9 @@ dl.list-features {
     text-align: center;
     background-color: #ffe761;
 
-    @include respond-min(768px) {
+    @include respond-min(46.25rem) {
         position: fixed;
-        min-width: 768px;
+        min-width: 46.25rem;
     }
 }
 
@@ -2488,7 +2495,7 @@ form {
         vertical-align: middle;
         width: 83%;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             padding: 6px 18% 8px 10px;
             width: 80%;
         }
@@ -2585,7 +2592,7 @@ form {
         top: 6%;
         width: 40px;
 
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             right: 1%;
         }
 
@@ -2616,7 +2623,7 @@ form {
             height: 30px;
             width: 30px;
             top: 3px;
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 right: 0;
             }
             i {
@@ -2625,7 +2632,7 @@ form {
         }
     }
     &.search {
-        @include respond-min(768px) {
+        @include respond-min(46.25rem) {
             flex: 0 0 40%;
             margin: 10px 0;
         }
@@ -2727,14 +2734,14 @@ div[role=main] {
         }
         &.previous {
             margin-right: 10px;
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 margin-right: 70px;
             }
         }
         &.next {
             margin-left: 10px;
             text-indent: 1px;
-            @include respond-min(768px) {
+            @include respond-min(46.25rem) {
                 margin-left: 70px;
             }
         }
@@ -3021,7 +3028,7 @@ ul.corporate-members li {
     }
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 46.24rem) {
 
     [role="banner"] .nav-menu-on .small-nav {
     

--- a/assets/css/output.scss
+++ b/assets/css/output.scss
@@ -9,4 +9,5 @@
 @import "print"; // print styles
 @import "opensearch";
 @import "partners";
-@import "community_projects"
+@import "community_projects";
+@import "custom-search";

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,270 @@
+/* Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+(() => {
+    const elInput = document.getElementById('search-input');
+    const elResults = document.getElementById('search-results');
+    const elOverlay = document.querySelector('.search-overlay');
+    const elSpinner = document.querySelector('.search-spinner');
+    if (!elInput || !elResults || !elOverlay) return;
+
+    const CLASSNAME_SPINNING = 'spinning';
+    const CLASSNAME_HIGHLIGHTED = 'highlighted';
+
+    const canSmoothScroll = 'scrollBehavior' in document.documentElement.style;
+
+    const docsVersion = elInput.getAttribute('data-docs-version');
+
+    let _showingResults = false,
+        animationFrame,
+        debounceTimer,
+        lastQuery;
+
+    const abortControllers = [];
+
+    elInput.addEventListener('input', e => {
+        debounceInput();
+    });
+
+    elInput.addEventListener('keydown', e => {
+        switch (e.key) {
+            case 'Esc':
+            case 'Escape':
+                hideResults(true);
+                elInput.value = '';
+                break;
+
+            case 'ArrowUp':
+                e.preventDefault();
+                highlightNextResult(false);
+                break;
+
+            case 'ArrowDown':
+                e.preventDefault();
+                highlightNextResult();
+                break;
+
+            case 'Enter':
+                e.preventDefault();
+                navToHighlightedResult();
+                break;
+
+            case 'Tab':
+                e.preventDefault();
+                highlightNextResult(!e.shiftKey);
+                break;
+
+        }
+    });
+
+    elInput.addEventListener('focus', e => {
+        if (!_showingResults && elResults.textContent) showResults();
+    });
+
+    elResults.addEventListener('pointerenter', e => {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = requestAnimationFrame(() => {
+            highlightResult(e.target?.closest('.custom-search-result'));
+        });
+    }, true);
+
+    elResults.addEventListener('focus', e => {
+        highlightResult(e.target?.closest('.custom-search-result'));
+    }, true);
+
+    const debounceInput = () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(doSearch, 300);
+    };
+
+    function abortPreviousCalls() {
+        while (abortControllers.length) abortControllers.pop()?.abort?.();
+    }
+
+    function getResultCategory(result) {
+        switch (result.type) {
+            case 'DOCS':
+                return `OpenSearch ${sanitizeText(result.version)}`;
+
+            default:
+                return result.type;
+        }
+    }
+
+    function getBreadcrumbs(result) {
+        const crumbs = [];
+        const cat = getResultCategory(result);
+        if (cat) crumbs.push(cat);
+
+        return sanitizeText(crumbs.join(' › '))
+    }
+
+    const doSearch = async () => {
+        const query = elInput.value.replace(/[^a-z0-9-_. ]+/ig, ' ');
+        if (query.length < 3) return hideResults(true);
+        if (query === lastQuery) return;
+
+        recordEvent('search', {
+            search_term: query,
+            docs_version: docsVersion
+        });
+
+        lastQuery = query;
+
+        abortPreviousCalls();
+
+        elSpinner?.classList.add(CLASSNAME_SPINNING);
+        if (!_showingResults) document.documentElement.classList.add('search-active');
+
+        try {
+            const controller = new AbortController();
+            abortControllers.unshift(abortControllers);
+            const startTime = Date.now();
+            const response = await fetch(`https://search-api.opensearch.org/search?q=${query}&v=${docsVersion}`, {signal: controller.signal});
+            const data = await response.json();
+
+            recordEvent('view_search_results', {
+                search_term: query,
+                docs_version: docsVersion,
+                duration: Date.now() - startTime,
+                results_num: data?.results?.length || 0
+            });
+
+            if (!Array.isArray(data?.results) || data.results.length === 0) {
+                return showNoResults();
+            }
+            const chunks = data.results.map(result => result
+                ? `
+                <div class="custom-search-result">
+                    <a href="${sanitizeAttribute(result.url)}">
+                        <cite>${getBreadcrumbs(result)}</cite>
+                        ${sanitizeText(result.title || 'Unnamed Document')}
+                    </a>
+                    <span>${sanitizeText(result.content?.replace?.(/\n/g, '&hellip; '))}</span>
+                </div>
+                `
+                : ''
+            );
+
+            emptyResults();
+            elResults.appendChild(document.createRange().createContextualFragment(chunks.join('')));
+            showResults();
+        } catch (ex) {
+            showNoResults();
+        }
+
+        elSpinner?.classList.remove(CLASSNAME_SPINNING);
+    }
+
+    const hideResults = destroy => {
+        _showingResults = false;
+
+        elSpinner?.classList.remove(CLASSNAME_SPINNING);
+        document.documentElement.classList.remove('search-active');
+        elResults.setAttribute('aria-expanded', 'false');
+        document.body.removeEventListener('pointerdown', handlePointerDown, false);
+
+        if (destroy) {
+            abortPreviousCalls();
+            emptyResults();
+            lastQuery = '';
+        }
+    };
+
+    const showResults = () => {
+        if (!_showingResults) {
+            _showingResults = true;
+            document.documentElement.classList.add('search-active');
+            elResults.setAttribute('aria-expanded', 'true');
+            document.body.addEventListener('pointerdown', handlePointerDown, false);
+        }
+
+        elResults.scrollTo(0, 0);
+    };
+
+    const showNoResults = () => {
+        emptyResults();
+        elResults.appendChild(document.createRange().createContextualFragment('<span>No results found!</span>'));
+        showResults();
+        elSpinner?.classList.remove(CLASSNAME_SPINNING);
+    };
+
+    const emptyResults = () => {
+        //ToDo: Replace with `elResults.replaceChildren();` when https://caniuse.com/?search=replaceChildren shows above 90% can use it
+        while (elResults.firstChild) elResults.firstChild.remove();
+    };
+
+    const sanitizeText = text => {
+        return text?.replace?.(/</g, '&lt;');
+    };
+
+    const sanitizeAttribute = text => {
+        return text?.replace?.(/[>"]+/g, '');
+    };
+
+    const handlePointerDown = e => {
+        if (e.target.matches('.search-input-wrap, .search-input-wrap *, .search-results, .search-results *')) return;
+
+        e.preventDefault();
+
+        elInput.blur();
+        hideResults();
+    };
+
+    const highlightResult = node => {
+        if (!node || !_showingResults || node.classList.contains(CLASSNAME_HIGHLIGHTED)) return;
+
+        elResults.querySelectorAll('.custom-search-result.highlighted').forEach(el => {
+            el.classList.remove(CLASSNAME_HIGHLIGHTED);
+        });
+        node.classList.add(CLASSNAME_HIGHLIGHTED);
+        elInput.focus();
+    };
+
+    const highlightNextResult = (down = true) => {
+        const highlighted = elResults.querySelector('.custom-search-result.highlighted');
+        let nextResult;
+        if (highlighted) {
+            highlighted.classList.remove(CLASSNAME_HIGHLIGHTED);
+            nextResult = highlighted[down ? 'nextElementSibling' : 'previousElementSibling']
+        } else {
+            nextResult = elResults.querySelector(`.custom-search-result:${down ? 'first' : 'last'}-child`);
+        }
+
+        if (nextResult) {
+            nextResult.classList.add(CLASSNAME_HIGHLIGHTED);
+            if (down) {
+                if (canSmoothScroll) {
+                    nextResult.scrollIntoView({behavior: "smooth", block: "end"});
+                } else {
+                    nextResult.scrollIntoView(false)
+                }
+            } else if (
+                nextResult.offsetTop < elResults.scrollTop ||
+                nextResult.offsetTop + nextResult.clientHeight > elResults.scrollTop + elResults.clientHeight
+            ) {
+                if (canSmoothScroll) {
+                    elResults.scrollTo({behavior: "smooth", top: nextResult.offsetTop, left: 0});
+                } else {
+                    elResults.scrollTo(0, nextResult.offsetTop);
+                }
+            }
+        } else {
+            elResults.scrollTo(0, 0);
+        }
+    };
+
+    const navToHighlightedResult = () => {
+        elResults.querySelector('.custom-search-result.highlighted a[href]')?.click?.();
+    };
+
+    const recordEvent = (name, data) => {
+        try {
+            gtag?.('event', name, data);
+        } catch (e) {
+            // Do nothing
+        }
+
+    }
+})();

--- a/index.markdown
+++ b/index.markdown
@@ -7,6 +7,8 @@ layout_class: sidebar-right
 body_class: homepage
 sectionid: homepage
 
+primary_title: About OpenSearch
+
 meta_description: OpenSearch is a community-driven, open source search and analytics suite derived from Apache 2.0 licensed Elasticsearch 7.10.2 & Kibana 7.10.2. It consists of a search engine daemon, OpenSearch, and a visualization and user interface, OpenSearch Dashboards. OpenSearch enables people to easily ingest, secure, search, aggregate, view, and analyze data.
 
 download_ctas:

--- a/source.markdown
+++ b/source.markdown
@@ -1,6 +1,7 @@
 ---
 layout: source
 body_class: source-page
+primary_title: 'Source Code'
 ---
 
 OpenSearch and OpenSearch Dashboards as well as the plugins and tools included in the OpenSearch Project are open source software with an Apache 2.0 license. We encourage you to use it all to the full extent of this license. 

--- a/versions/index.html
+++ b/versions/index.html
@@ -1,5 +1,6 @@
 ---
 layout: fullwidth
+omit_from_search: true
 ---
 <ul>
   {% assign versions = site.versions | sort: 'date' | reverse %}


### PR DESCRIPTION
### Description
* Add a plugin that produces indexible content: This content is fed to OpenSearch and made available via https://search-api.opensearch.org/search
* Add a search text input, identical to the one used on documentation
* Converted some `768px` media queries to `46.25rem` which is `740px` (matching [defaults from just-the-docs](https://pmarsceill.github.io/just-the-docs/docs/utilities/responsive-modifiers/) so the website and docsite appear uniform)
* Set `versions` landing page to `omit_from_search: true`
* Moved the title of `source` from config to the page itself as it was used once and helps simplify indexing
 

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
