### PR TITLE
Added Data Prepper 1.2.1 archives.

### DIFF
--- a/_artifacts/data-prepper/data-prepper-1.2.1-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-1.2.1-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-1.2.1
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/1.2.1/opensearch-data-prepper-jdk-1.2.1-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/1.2.1/opensearch-data-prepper-jdk-1.2.1-linux-x64.tar.gz.sig
+slug: data-prepper-jdk-1.2.1-linux-x64
+category: opensearch
+---

--- a/_artifacts/data-prepper/data-prepper-1.2.1-no-jdk-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-1.2.1-no-jdk-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper-no-jdk
+version: data-prepper-1.2.1
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/1.2.1/opensearch-data-prepper-1.2.1-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/1.2.1/opensearch-data-prepper-1.2.1-linux-x64.tar.gz.sig
+slug: data-prepper-1.2.1-linux-x64
+category: opensearch
+---

--- a/_includes/downloads/data-prepper.html
+++ b/_includes/downloads/data-prepper.html
@@ -1,2 +1,2 @@
 Data Prepper is a component of the OpenSearch project that accepts, filters, transforms, enriches, and routes data at scale.
-Distributions without a bundled are also available in the <a href="/artifacts">artifacts directory</a>.
+Distributions without a bundled JDK are also available in the <a href="/artifacts">artifacts directory</a>.

--- a/_includes/downloads/data-prepper.html
+++ b/_includes/downloads/data-prepper.html
@@ -1,1 +1,2 @@
 Data Prepper is a component of the OpenSearch project that accepts, filters, transforms, enriches, and routes data at scale.
+Distributions without a bundled are also available in the <a href="/artifacts">artifacts directory</a>.

--- a/_layouts/versions.html
+++ b/_layouts/versions.html
@@ -15,6 +15,7 @@ pretty:
     odfe-jdbc: JDBC Driver
     odfe-odbc: ODBC Driver
     data-prepper: Data Prepper
+    data-prepper-no-jdk: Data Prepper (without bundled JDK)
     logstash-oss-with-opensearch-output-plugin: Logstash OSS with OpenSearch Output Plugin
   platforms:
     windows: "Windows"

--- a/_versions/2021-07-12-opensearch-1.0.0.markdown
+++ b/_versions/2021-07-12-opensearch-1.0.0.markdown
@@ -26,6 +26,9 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-09-01-opensearch-1.0.1.markdown
+++ b/_versions/2021-09-01-opensearch-1.0.1.markdown
@@ -26,6 +26,9 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-10-05-opensearch-1.1.0.markdown
+++ b/_versions/2021-10-05-opensearch-1.1.0.markdown
@@ -26,6 +26,9 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-11-23-opensearch-1.2.0.markdown
+++ b/_versions/2021-11-23-opensearch-1.2.0.markdown
@@ -26,6 +26,9 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-11-opensearch-1.2.1.markdown
+++ b/_versions/2021-12-11-opensearch-1.2.1.markdown
@@ -26,6 +26,9 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-16-opensearch-1.2.2.markdown
+++ b/_versions/2021-12-16-opensearch-1.2.2.markdown
@@ -26,6 +26,9 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-22-opensearch-1.2.3.markdown
+++ b/_versions/2021-12-22-opensearch-1.2.3.markdown
@@ -26,6 +26,9 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/_2021-12-14-opensearch-1.1.1.markdown
+++ b/_versions/_2021-12-14-opensearch-1.1.1.markdown
@@ -26,6 +26,13 @@ components:
     role: ingest
     artifact: data-prepper
     version: data-prepper-1.2.1
+    platform_order:
+      - docker
+      - linux
+      - macos
+      - windows
+      - freebsd
+      - java
   -
     role: minimal-artifacts
     artifact: opensearch-min


### PR DESCRIPTION
### Description

This PR adds Data Prepper archive files for Linux.

Additionally, Data Prepper includes a bundle without an embedded JDK. I took the approach of referring users to the archives directory for this artifact. This is similar to how the OpenDistro Data Prepper download page worked.
 
### Issues Resolved

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
