### PR TITLE
Remove jcenter repository reference in blog post

### DIFF
--- a/_posts/2021-06-03-my-first-steps-in-opensearch-plugins.markdown
+++ b/_posts/2021-06-03-my-first-steps-in-opensearch-plugins.markdown
@@ -193,7 +193,6 @@ opensearchplugin {
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         mavenLocal()
     }
 


### PR DESCRIPTION
### Description
We are removing all jcenter references from our code base, it seems appropriate to also update this blog post as well.  See more details on https://github.com/opensearch-project/opensearch-build/issues/1456.
 
### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
