### PR TITLE
Fixes several occurrences of `the the`

### DIFF
--- a/_posts/2021-07-08-how-to-upgrade-from-opendistro-to-opensearch.markdown
+++ b/_posts/2021-07-08-how-to-upgrade-from-opendistro-to-opensearch.markdown
@@ -56,7 +56,7 @@ And finally, now that you are ready for the upgrade, you should download the lat
 
 ### Types of Upgrade
 
-Now that you have taken your snapshot, and validated the recommended upgrade path for your existing cluster, we can move on the the upgrade itself. We are going to provide instructions on 3 types of upgrades.
+Now that you have taken your snapshot, and validated the recommended upgrade path for your existing cluster, we can move on to the upgrade itself. We are going to provide instructions on 3 types of upgrades.
 
 1. **Snapshot Upgrade**: A snapshot upgrade involves taking a snapshot of the current cluster, spinning up a new cluster, and then restoring from the snapshot. Depending on how you do this, there may or may not be downtime. 
 2. **Restart Upgrade**: A restart upgrade involves taking down the whole cluster, upgrading it, and then starting it back up. This will include downtime.

--- a/_posts/2021-08-27-what-is-semver.markdown
+++ b/_posts/2021-08-27-what-is-semver.markdown
@@ -31,7 +31,7 @@ SemVer aside, when software breaks on a minor or patch version people tend to ge
 Unintuitively, SemVer does not indicate the drastic-ness of the change. Let's take a few scenarios:
 
 1. A patch version is released that fixes a major conceptual misunderstanding. This patch version could change *thousands* of lines of code, yet as long as it's not a new feature and doesn't change the API or data formats, it's still a valid patch release.
-2. A minor version includes dozens of new features. As long as the existing APIs and data formats are not disturbed by the the new features, this is still a valid minor release. 
+2. A minor version includes dozens of new features. As long as the existing APIs and data formats are not disturbed by the new features, this is still a valid minor release. 
 3. An API endpoint is misspelled and is corrected. Under SemVer, this correction might only be *a single byte change*, but it would be considered a major release. Granted, if spelling issues in the API are being released, this is indicative of other quality issues that probably also need attention! 
 
 That’s the biggest mental hurdle - a major version does not indicate a major leap forward or lots of new features. It just means that it’s breaking compatibility.

--- a/assets/js/lib/webfontloader/spec/core/eventdispatcher_spec.js
+++ b/assets/js/lib/webfontloader/spec/core/eventdispatcher_spec.js
@@ -159,7 +159,7 @@ describe('EventDispatcher', function () {
       eventDispatcher.dispatchInactive();
     });
 
-    it('should not set the the inactive class', function () {
+    it('should not set the inactive class', function () {
       expect(element.className).toEqual('ns-active');
     });
 


### PR DESCRIPTION
Minor/Trivial grammatical fix, removing occurrences of `the the` in prose.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
