### PR TITLE
Add link to blog post for latest Data Prepper performance test results

### DIFF
--- a/_posts/2022-02-01-data-prepper-1.2.1-performance-testing.md
+++ b/_posts/2022-02-01-data-prepper-1.2.1-performance-testing.md
@@ -100,3 +100,7 @@ Table [1] - AWS Environment Details
 | Logstash Prometheus + Grafana     | m5.xlarge         |              1 |    4 |           16 |                        |
 | Logstash OpenSearch Cluster       | i3.xlarge         |              3 |    4 |         30.5 |                        |
 | Gatling                           | m5.2xlarge        |              1 |    8 |           32 |                        |
+
+## Latest Performance Test Results
+
+Follow this link to see the [Latest Performance Test Results](https://github.com/opensearch-project/data-prepper/blob/main/docs/latest_performance_test_results.md)


### PR DESCRIPTION
Signed-off-by: Taylor Gray <tylgry@amazon.com>

### Description
* Adds a link to to the Data Prepper 1.2.1 performance blog post, which takes the reader to a document in the Data Prepper repo for the latest performance test results.

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
