### PR TITLE
updates maintainers to reflect actual members

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,19 @@
 ## Maintainers
 
+
+### Current Maintainers
 | Maintainer | GitHub ID | Affiliation |
 | --------------- | --------- | ----------- |
-| Kyle Davis | [stockholmux](https://github.com/stockholmux) | Amazon |
 | Eli Fisher | [elfisher](https://github.com/elfisher) | Amazon |
+| Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon |
+| Nick Knize | [nknize](https://github.com/nknize) | Amazon |
+| Kris Freedain | [krisfreedain](https://github.com/krisfreedain) | Amazon |
+| Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
+| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
+
+### Emeritus Maintainers
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Kyle J. Davis | [stockholmux](https://github.com/stockholmux) | Amazon |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Kyle J. Davis <kyledvs@amazon.com>

### Description
- Moves Kyle to Emeritus
- Adds Miki, Nick, Kris, Peter and Charlotte as maintainers (present in team, but not in markdown)

 
### Issues Resolved
n/a

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
