### PR TITLE
Fixes misconfigured source from otel_trace to otel_metrics

### DIFF
--- a/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
+++ b/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
@@ -94,7 +94,7 @@ You just need to configure the source and processor plugins:
 ```yaml
 metrics-pipeline:
   source:
-    otel_trace_source:
+    otel_metrics_source::
   processor:
     - otel_metrics_raw_processor:
   sink:


### PR DESCRIPTION
Signed-off-by: Shivani Shukla <sshkamz@amazon.com>

### Description

- While referring to this [Metrics Ingestion with Data Prepper Blog](https://opensearch.org/blog/technical-post/2022/05/opentelemetry-metrics-for-data-prepper/), I observed the `source` in the Configuration was misconfigured as the trace source instead of the metrics source. This PR updates the source from `otel_trace_source` to the correct `otel_metrics_source`. 
- The updated configuration with `otel_metrics_source` was also tested manually. 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
