### PR TITLE
Fixed typos in FAQ questions 1.21 and 2.4

### DIFF
--- a/_faqs/01-21-what-tools-do-you-recommend-for-log-aggregation.markdown
+++ b/_faqs/01-21-what-tools-do-you-recommend-for-log-aggregation.markdown
@@ -3,4 +3,4 @@ question: What tools do you recommend for log aggregation?
 category: General
 ---
 
-OpenSearch is supported by a range of tools like Data Prepper, Fluentd, Logstash, and Kafka. OpenSearch believes in multiple open source options and will focus on improving the Data Prepper, Fluentd, and Kakfa support going forward.
+OpenSearch is supported by a range of tools like Data Prepper, Fluentd, Logstash, and Kafka. OpenSearch believes in multiple open source options and will focus on improving the Data Prepper, Fluentd, and Kafka support going forward.

--- a/_faqs/02-04-does-opensearch-include-forks-of-logstash-and-beats.markdown
+++ b/_faqs/02-04-does-opensearch-include-forks-of-logstash-and-beats.markdown
@@ -1,5 +1,5 @@
 ---
-question: Does OpenSearch include forks of logstash and beats?
+question: Does OpenSearch include forks of Logstash and Beats?
 category: Tools and Plugins
 ---
 


### PR DESCRIPTION
Fixes two typos in the FAQ called out in https://github.com/opensearch-project/documentation-website/issues/728

### Description
Fixed two typos in questions 1.21 and 2.4
 
### Issues Resolved
This PR doesn't resolve an issue in and of itself - there will need to be another PR against the documentation-website repo.

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
