### PR TITLE
Fix minimal artifact 2.1.0 download versions

### DIFF
--- a/_versions/2022-07-07-opensearch-2.1.0.markdown
+++ b/_versions/2022-07-07-opensearch-2.1.0.markdown
@@ -25,10 +25,10 @@ components:
       - linux
   - role: minimal-artifacts
     artifact: opensearch-min
-    version: 2.0.1
+    version: 2.1.0
   - role: minimal-artifacts
     artifact: opensearch-dashboards-min
-    version: 2.0.1
+    version: 2.1.0
   - role: drivers
     artifact: opensearch-sql-odbc
     version: 1.1.0.1


### PR DESCRIPTION
Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>

### Description

At the 2.1.0 download page <https://opensearch.org/versions/opensearch-2-1-0.html> the minimal artifact versions point to 2.0.1.
This PR fixes this issue.

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
