### PR TITLE
Fix OTel Metrics Source DataPrepper Example

### DIFF
--- a/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
+++ b/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
@@ -94,7 +94,8 @@ You just need to configure the source and processor plugins:
 ```yaml
 metrics-pipeline:
   source:
-    otel_metrics_source::
+    otel_metrics_source:
+      ssl: false
   processor:
     - otel_metrics_raw_processor:
   sink:
@@ -102,6 +103,7 @@ metrics-pipeline:
       hosts: [ "https://opensearch.local:9200" ]
       username: username
       password: password
+      index: metrics-otel-v1-%{yyyy.MM.dd}
 ```
 
 The metric source supports the same configuration as the OpenTelemetry trace source.

--- a/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
+++ b/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
@@ -95,7 +95,6 @@ You just need to configure the source and processor plugins:
 metrics-pipeline:
   source:
     otel_metrics_source:
-      ssl: false
   processor:
     - otel_metrics_raw_processor:
   sink:


### PR DESCRIPTION
### Description
There was a typo in the example metrics pipeline configuration (cf. [1]). It was fixed to provide a working configuration. An appropriate index configuration was added as well.

[1] https://stackoverflow.com/questions/73601327/export-opentelemetry-metrics-to-open-search/73631163
 
### Issues Resolved
Fixed typo in example configuration for DataPrepper OTLP metrics source.

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
