### PR TITLE
Replacing sarif includes with sans-serif includes to fix #1046

### DIFF
--- a/_sass/_opensearch.scss
+++ b/_sass/_opensearch.scss
@@ -153,7 +153,7 @@ dl.list-features {
 }
 
 .homepage .list-features dt {
-    @include serif;
+    @include sans-serif;
 }
 
 .homepage .list-features p + dt {

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -19,7 +19,7 @@ html {
 }
 
 body {
-    @include serif;
+    @include sans-serif;
     @include font-size(18);
     background: $background-darker;
     color: $text;


### PR DESCRIPTION
Signed-off-by: Nathan Boot <nateboot@amazon.com>

### Description

Replaces sass style includes of sarif with sans-serif to return us to the open source "Open Sans" font. 
 
### Issues Resolved
#1046 

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
