### PR TITLE
Add @dtaivpp as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@
 | Kris Freedain | [krisfreedain](https://github.com/krisfreedain) | Amazon |
 | Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
 | Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
+| David Tippett | [dtaivpp](https://github.com/dtaivpp) | Amazon |
 
 ### Emeritus Maintainers
 | Maintainer | GitHub ID | Affiliation |


### PR DESCRIPTION
Signed-off-by: Kris Freedain <freedak@amazon.com>

### Description
Following https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#addition to update maintainer list with nominees. The maintainers have voted and agreed to this nomination and the nominee confirmed their interest in becoming co-maintainer.

### Detail from nomination:
I would like to maintain we add David Tippet as a maintainer on the project-website. He is a Sr Developer Advocate on the OpenSearch project. Full profile here: https://github.com/dtaivpp
He has helped on a number of
PRs:
https://github.com/opensearch-project/project-website/pulls?q=is%3Apr+dtaivpp+
Issues:
https://github.com/opensearch-project/project-website/issues?q=is%3Aissue+dtaivpp+
 
And has assisted me with input on code, Jekyll questions a number of times.
 
### Issues Resolved
N/A

### Check List
- [ x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
