### PR TITLE
Hacktoberfest blog post: don't use `git commit -m`

### DIFF
--- a/_posts/2022-10-03-hacktoberfest-2022.md
+++ b/_posts/2022-10-03-hacktoberfest-2022.md
@@ -46,7 +46,7 @@ I am so glad you asked! For contributions, I recommend you start small. OpenSear
 
 Once you have found an issue you would like to work on, you should check out their `CONTRIBUTING.md` file. It will take you through the process of contributing to that particular repo. Also, if you are contributing to a particular issue, it is helpful to comment on it to let others know you are working on it. 
 
-Generally, the process for contributing involves forking the repository, making your edit (don’t forget to sign your commits using -s in your commit message: `git commit -s -m "<your commit message>"`), and then submitting a pull request (PR). This guide goes into much more detail: [First Contribution Guide](https://github.com/firstcontributions/first-contributions).
+Generally, the process for contributing involves forking the repository, making your edit (don’t forget to sign your commits using -s in your commit message: `git commit -s`), and then submitting a pull request (PR). This guide goes into much more detail: [First Contribution Guide](https://github.com/firstcontributions/first-contributions).
 
 If you have questions along the way, you can always @ mention one of the maintainers on the issue. You can find the maintainers in the `MAINTAINERS.md` file for that repo. Please be patient as the maintainers may take several days to reply depending on their capacity. If more than a few days goes by without a response, feel free to reach out to another maintainer. 
 


### PR DESCRIPTION
### Description
Don't suggest the usage of using the `-m` option to define a commit-msg directly when running the command. This leads to super ugly commit messages as you can essentially only define a single line and don't have any guidance on the length. As Hacktoberfest is esp. used by new developers this will lead them down the wrong path.

Probably the best explanation of proper commit messages can be found in [this blog post from 2008][tbaggery] (Linus Torvalds - the guy who invented both Linux and Git - also [confirmed][linus] that this lists all the rules for good commit messages).

[tbaggery]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[linus]: https://github.com/torvalds/linux/pull/17#issuecomment-5663733

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>

### Issues Resolved
n/a

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
