### PR TITLE
Display latest 1.x version next to latest 2.x version

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -72,14 +72,15 @@ layout: default
       <a href="{{ page.ctas.roadmap.url }}" class="link-readmore" target="_blank">{{ page.ctas.roadmap.text }}</a>
       {% assign versions = site.versions | sort: 'version_sort' | reverse %}
       {% assign latest = versions | first %}
+      {% assign previous_major = latest.version | split: "." | first | plus: -1 %}
       {% for version in versions %}
-          {% assign major_version = version.version | split: "." | first %}
-          {% if major_version == 1 %}
+          {% assign major_version = version.version | split: "." | first | plus: 0 %}
+          {% if major_version == previous_major %}
             {% assign latest_first = version %}
             {% break %}
-          {%endif%}
+          {% endif %}
       {% endfor %}
-      <div class="latest-version">{{ page.version_feature.latest_label}} {{ latest.version }} {{ page.version_feature.date_label}} {{ latest_first.version }} {{ page.version_feature.date_label}} {{ latest.date | date_to_string: "ordinal", "US"}}</div>
+      <div class="latest-version">{{ page.version_feature.latest_label }} {{ latest.version }} {{ page.version_feature.date_label }} {{ latest_first.version }} {{ page.version_feature.date_label }} {{ latest.date | date_to_string: "ordinal", "US" }}</div>
 
       
       <div class="whats-new">

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -70,8 +70,16 @@ layout: default
       </a>
       {% endif %}
       <a href="{{ page.ctas.roadmap.url }}" class="link-readmore" target="_blank">{{ page.ctas.roadmap.text }}</a>
-      {% assign latest = site.versions | sort: 'version_sort' | reverse | first %}
-      <div class="latest-version">{{ page.version_feature.latest_label}} {{ latest.version }} {{ page.version_feature.date_label}} {{ latest.date | date_to_string: "ordinal", "US"}}</div>
+      {% assign versions = site.versions | sort: 'version_sort' | reverse %}
+      {% assign latest = versions | first %}
+      {% for version in versions %}
+          {% assign major_version = version.version | split: "." | first %}
+          {% if major_version == 1 %}
+            {% assign latest_first = version %}
+            {% break %}
+          {%endif%}
+      {% endfor %}
+      <div class="latest-version">{{ page.version_feature.latest_label}} {{ latest.version }} {{ page.version_feature.date_label}} {{ latest_first.version }} {{ page.version_feature.date_label}} {{ latest.date | date_to_string: "ordinal", "US"}}</div>
 
       
       <div class="whats-new">


### PR DESCRIPTION
Signed-off-by: Michael Zhou <mizho@alumni.upenn.edu>

### Description
Displays the latest 1.x line version next to the latest 2.x line version on the website homepage
 
### Issues Resolved
#971 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
