### PR TITLE
Move Founding Documents

### DIFF
--- a/_posts/2022-10-10-Announcing-Data-Prepper-2.0.0.md
+++ b/_posts/2022-10-10-Announcing-Data-Prepper-2.0.0.md
@@ -20,8 +20,8 @@ Here are some of the major changes and enhancements made for Data Prepper 2.0.
 Data Prepper 2.0 supports conditional routing to help pipeline authors send different logs to specific OpenSearch clusters.
 
 One common use case for conditional routing is reducing the volume of data going to some clusters.
-When you want info logs that produce large volumes of data to go to a cluster, to index with more frequent rollovers, or to add deletions to clear out large volumes of data, you can now configure pipelines to route the data with your chosen action.
-deletions to clear out these large volumes of data, you now configure pipelines to route your data.
+When you want info logs that produce large volumes of data to go to a cluster, to index with more frequent rollovers, or to 
+add deletions to clear out large volumes of data, you can now configure pipelines to route the data with your chosen action.
 
 
 Simply choose a name appropriate for the domain and a Data Prepper expression. 

--- a/about.markdown
+++ b/about.markdown
@@ -5,9 +5,9 @@ title: About
 ---
 
 ## About
-_Updated May 19, 2022_
+_Updated October 14, 2022_
 
-[Principles for development](#principles-for-development) &middot; [OpenSearch disambiguation](#opensearch-disambiguation) &middot;
+[Principles for development](#principles-for-development) &middot; [Founding Documents](#founding-documents) &middot; [OpenSearch disambiguation](#opensearch-disambiguation) &middot;
 
 ---
 
@@ -46,6 +46,12 @@ This will be a community where you will be heard, accepted, and valued, whether 
  
 ### A place to invent. ###
 You will be able to innovate rapidly. This project will have a stable and predictable foundation that is modular, making it easy to extend.
+
+## Founding Documents ##
+
+* [Introducing OpenSearch](https://aws.amazon.com/blogs/opensource/introducing-opensearch)
+* [Stepping up for a truly open source Elasticsearch](https://aws.amazon.com/blogs/opensource/stepping-up-for-a-truly-open-source-elasticsearch/)
+* [Keeping Open Source Open](https://aws.amazon.com/blogs/opensource/keeping-open-source-open-open-distro-for-elasticsearch/)
 
 ## OpenSearch disambiguation ##
 At the 2005 O’Reilly Emerging Technology Conference, Jeff Bezos [showed the world](https://www.technologyreview.com/2005/03/15/231423/jeff-bezos-unveils-vertical-search-live-from-the-oreilly-e-tech-conference/) the OpenSearch syndication protocol. You can find more details on [Wikipedia](https://en.wikipedia.org/wiki/OpenSearch). This specification is maintained in GitHub at [github.com/dewitt/opensearch](http://github.com/dewitt/opensearch).

--- a/index.markdown
+++ b/index.markdown
@@ -99,20 +99,20 @@ sidebar:
                 title: Ask in the forum
                 url: https://forum.opensearch.org/
     -
-        title: Founding documents
+#       title: Founding documents
 #        more: 
 #            title: 'Read all the founding documents'
 #            url: http://www.example.com/
-        links:
-            -
-                title: Introducing OpenSearch
-                url: https://aws.amazon.com/blogs/opensource/introducing-opensearch
-            -
-                title: 'Stepping up for a truly open source Elasticsearch'
-                url: https://aws.amazon.com/blogs/opensource/stepping-up-for-a-truly-open-source-elasticsearch/
-            -
-                title: 'Keeping Open Source Open'
-                url: https://aws.amazon.com/blogs/opensource/keeping-open-source-open-open-distro-for-elasticsearch/
+#       links:
+#           -
+#               title: Introducing OpenSearch
+#               url: https://aws.amazon.com/blogs/opensource/introducing-opensearch
+#           -
+#               title: 'Stepping up for a truly open source Elasticsearch'
+#               url: https://aws.amazon.com/blogs/opensource/stepping-up-for-a-truly-open-source-elasticsearch/
+#           -
+#               title: 'Keeping Open Source Open'
+#               url: https://aws.amazon.com/blogs/opensource/keeping-open-source-open-open-distro-for-elasticsearch/
 
 notice : true
 


### PR DESCRIPTION
### Description
This change moves the Founding Documents from the front page to a section on the About page
 
### Issues Resolved
n/a

### Check List
- [ x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
