### PR TITLE
Adding google analytics snippet to homepage layout (#1099)

### DIFF
--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,0 +1,8 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1S08ZMDPBF"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-1S08ZMDPBF');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -61,13 +61,5 @@
 
     <link rel="stylesheet" href="{{'assets/css/output.css' | relative_url }}" >
     <script src="{{ 'assets/js/lib/modernizr.js' | relative_url }}"></script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BQV14XK08F"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-BQV14XK08F');
-    </script>
     {{ page.head_extra }}
   </head>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -102,5 +102,5 @@ layout: default
 
 {% endcapture %}
 
-
+{% include google_analytics.html %}
 {% include base_3col.html %}


### PR DESCRIPTION
Signed-off-by: Nathan Boot <nateboot@amazon.com>

### Description

Adds GA snippet to bottom of OpenSearch.org page. 
 
### Issues Resolved

#1099 

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
