### PR TITLE
Release Data Prepper 1.5.2

### DIFF
--- a/_artifacts/data-prepper/data-prepper-1.5.2-docker-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-1.5.2-docker-x64.markdown
@@ -1,0 +1,21 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-1.5.2
+platform: docker
+type: docker
+architecture: x64
+slug: data-prepper-1.5.2-docker-x64
+category: opensearch
+inline_instructions:
+- label: "Docker Hub"
+  code: docker pull opensearchproject/data-prepper:1.5.2
+  link:
+    label: View on Docker Hub
+    url: https://hub.docker.com/r/opensearchproject/data-prepper/tags?page=1&ordering=last_updated&name=1.5.2
+- label: "Amazon ECR"
+  code: docker pull public.ecr.aws/opensearchproject/data-prepper:1.5.2
+  link:
+    label: View on Amazon ECR
+    url: https://gallery.ecr.aws/opensearchproject/data-prepper
+---

--- a/_artifacts/data-prepper/data-prepper-1.5.2-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-1.5.2-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-1.5.2
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/1.5.2/opensearch-data-prepper-jdk-1.5.2-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/1.5.2/opensearch-data-prepper-jdk-1.5.2-linux-x64.tar.gz.sig
+slug: data-prepper-jdk-1.5.2-linux-x64
+category: opensearch
+---

--- a/_artifacts/data-prepper/data-prepper-1.5.2-no-jdk-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-1.5.2-no-jdk-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper-no-jdk
+version: data-prepper-1.5.2
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/1.5.2/opensearch-data-prepper-1.5.2-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/1.5.2/opensearch-data-prepper-1.5.2-linux-x64.tar.gz.sig
+slug: data-prepper-1.5.2-linux-x64
+category: opensearch
+---


### PR DESCRIPTION
### Description

This PR adds Data Prepper 1.5.2. This release is not linked to any OpenSearch version because 2.0.1 is preferable.
 
### Issues Resolved
N/A

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
