### PR TITLE
Fix image on the build system blog post

### DIFF
--- a/_posts/2022-10-24-public-jenkins.markdown
+++ b/_posts/2022-10-24-public-jenkins.markdown
@@ -22,7 +22,7 @@ The manual processes also required development teams to create, own, and maintai
 
 ### OpenSearch CI/CD infrastructure design
 Figure 1 depicts a high-level overview of the CI system architecture.
-![Figure 1: Jenkins Infrastructure Overview]({{ site.baseurl }}assets/media/blog-images/2022-10-24-public-jenkins.markdown/jenkins.png){: .img-fluid }**Figure 1**: Jenkins Infrastructure Overview
+<img src="assets/media/blog-images/2022-10-24-public-jenkins.markdown/jenkins.png" alt="Jenkins Infrastructure Overview"/>{: .img-fluid }
 
 ### Overview of the Jenkins workflow(s)
 

--- a/_posts/2022-10-24-public-jenkins.markdown
+++ b/_posts/2022-10-24-public-jenkins.markdown
@@ -23,7 +23,7 @@ The manual processes also required development teams to create, own, and maintai
 ### OpenSearch CI/CD infrastructure design
 Figure 1 depicts a high-level overview of the CI system architecture.
 
- ![Figure 1: Jenkins Infrastructure Overview]({{ site.baseurl }}/assets/media/blog-images/2022-10-24-public-jenkins.markdown/jenkins.png){: .img-fluid }Figure 1: Jenkins Infrastructure Overview
+![Figure 1: Jenkins Infrastructure Overview]({{ site.baseurl }}/assets/media/blog-images/2022-10-24-public-jenkins.markdown/jenkins.png){: .img-fluid }**Figure 1**: Jenkins Infrastructure Overview
 
 ### Overview of the Jenkins workflow(s)
 

--- a/_posts/2022-10-24-public-jenkins.markdown
+++ b/_posts/2022-10-24-public-jenkins.markdown
@@ -22,7 +22,8 @@ The manual processes also required development teams to create, own, and maintai
 
 ### OpenSearch CI/CD infrastructure design
 Figure 1 depicts a high-level overview of the CI system architecture.
-<img src="assets/media/blog-images/2022-10-24-public-jenkins.markdown/jenkins.png" alt="Jenkins Infrastructure Overview"/>{: .img-fluid }
+
+ ![Figure 1: Jenkins Infrastructure Overview]({{ site.baseurl }}/assets/media/blog-images/2022-10-24-public-jenkins.markdown/jenkins.png){: .img-fluid }Figure 1: Jenkins Infrastructure Overview
 
 ### Overview of the Jenkins workflow(s)
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The image on the blog post https://opensearch.org/blog/community/2022/10/public-jenkins/ appears to be broken. This change fixes that
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
