### PR TITLE
Fix: Updated Data Prepper artifact version

### DIFF
--- a/_versions/2022-10-06-opensearch-1.3.6.markdown
+++ b/_versions/2022-10-06-opensearch-1.3.6.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.4.0
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-1.5.1
+    version: data-prepper-2.0.1
     platform_order:
       - docker
       - linux


### PR DESCRIPTION
Signed-off-by: Asif Sohail Mohammed <nsifmoh@amazon.com>

### Description
Updates Data Prepper artifact version from 1.5.1 to 2.0.1 in one of the OpenSearch 1.3.6 markdown file
 
### Issues Resolved

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
