### PR TITLE
#1115 Momentum Stats Carousel

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,6 +76,8 @@ defaults:
       permalink: :collection/:slug.html
 
 collections:
+  momentumstats: 
+    output: false
   authors:
     output: true
   partners:

--- a/_includes/momentumstats-carousel-slide.html
+++ b/_includes/momentumstats-carousel-slide.html
@@ -1,0 +1,15 @@
+<!-- Include the content if it's not type image. Otherwise, just show the stat_img and link it to stat_url. -->
+
+<div class="momentumstats-slide">
+
+	{% if momentumstat.stat_type == "image" %}
+		<a href="{{ momentumstat.stat_url }}">
+			<img class="momentumstat-image" src="{{momentumstat.stat_img}}">
+		</a>
+	{% else %}
+		<span class="momentumstat-html">
+			{{ include.momentumstat.content }}
+		</span>
+	{% endif %}
+        
+</div>

--- a/_includes/momentumstats-carousel.html
+++ b/_includes/momentumstats-carousel.html
@@ -1,0 +1,46 @@
+{% assign mstats = site.momentumstats | where: "display", "true" %}
+
+{% if mstats.size > 0 %}
+	<style type="text/css">
+		img.momentumstat-image
+		{
+			width: 420px;
+		}
+		
+	</style>
+
+	<h3>
+		Check out some of our momentum!
+	</h3>
+
+	<div class="momentumstats-carousel-container">
+
+		{% for momentumstat in mstats %}
+			<div class="momentumstats-slide-container" id="momentumslide{{ forloop.index0 }}"
+				{% if forloop.first %}
+					style="display: inline;"
+				{% else %}
+					style="display: none;"
+				{% endif %}
+				>
+				{% include momentumstats-carousel-slide.html momentumstat=momentumstat %}
+			</div>
+		{% endfor %}
+	</div>
+
+	<script language='javascript'>
+		setInterval(function() {
+			thingies = jQuery(".momentumstats-slide-container");
+			for(i = 0; i < thingies.length; i++)
+			{
+					if($("div#momentumslide" + i).is(":visible"))
+					{
+							$("div#momentumslide" + i).toggle();
+							$("div#momentumslide" + ((i + 1) % thingies.length)).toggle();
+							break;
+					}
+			}
+		}, 20000);
+	</script>
+{% endif %}
+

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -74,6 +74,8 @@ layout: default
       {% assign latest = site.versions | sort: 'version_sort' | reverse | first %}
       <div class="latest-version">{{ page.version_feature.latest_label}} {{ latest.version }} {{ page.version_feature.date_label}} {{ latest.date | date_to_string: "ordinal", "US"}}</div>
 
+	{% include momentumstats-carousel.html %}
+
 	{% include feedback.html %}
 
       <div class="whats-new">

--- a/_momentumstats/template.markdown
+++ b/_momentumstats/template.markdown
@@ -1,0 +1,18 @@
+---
+# stat_type: {image, html}
+# stat_url: {destination_url_on_click}
+# stat_img: https://imageurlhere/image.jpg
+# display: {true, false}
+display: false
+---
+This is the freeform text of a momentum statistic. The presentation template shall:
+
+1. Filter momentum stats with the 'display' attribute of 'true' 
+
+For those stats, 
+
+2. Determine the *type* of the stat. 
+
+* If the stat is of type image, display the image, make it link to "stat_url"
+* If the stat is of type html, render the freeform text as is. A link will be added at the end to link to "stat_url"
+* If the stat has a display attribute of false, do not display it. 


### PR DESCRIPTION
Signed-off-by: Nate Boot <nateboot@amazon.com>

### Description
Adds a section currently above the feedback section that shows 'momentum stats'. 

Stats take the form of markdown and yaml frontmatter, and all live inside of _momentumstats. They can be an `html` stat, or an `image` stat. Image stats just show the image and links it to `stat_url` frontmatter value. (See `template.markdown` in _momentumstats)

Their presence is determined by the frontmatter attribute `display` being `true`. 

If there are no stats with a display value of true, the section does not appear. 
 
### Issues Resolved
#1115 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
