### PR TITLE
Allowing for frontmatter-defined meta_description and meta_keyword.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,8 +5,17 @@
     <meta name="ROBOTS" content="ALL" />
     <meta name="MSSmartTagsPreventParsing" content="true" />
     <meta name="Copyright" content="" />
-    <meta name="keywords" content="open-source, search, opensearch" />
+
+    <meta name="keywords" content="
+		{% if page.meta_keywords %} 
+			{{ page.meta_keywords }} 
+		{% else %} 
+			open-source, search, opensearch 
+		{% endif %}" 
+	/>
+
     {% feed_meta %}
+
     {% if page.meta_description %}<meta name="description" content="{{ page.meta_description }}" />{%endif%}
     
     {% assign pagetitle = page.title | strip_newlines %}

--- a/_posts/2022-03-09-fine-dining-for-indices.md
+++ b/_posts/2022-03-09-fine-dining-for-indices.md
@@ -9,6 +9,9 @@ categories:
  - intro
 
 excerpt: "There are a lot of reasons you might want to fine-tune indices on an OpenSearch cluster. Every workflow has different requirements, and the default behavior of OpenSearch might not suit your use case. Before ingesting with reckless abandon to fill an index with data, enjoy some insight on tuning an index. "
+meta_description: "This article helps create the most efficient OpenSearch index mapping that you can think of."
+meta_keywords: "data ingestion, indices, opensearch, index mapping"
+
 ---
 
 ## Is Your Cluster Eating Healthy? 

--- a/_posts/2022-07-20-content-compass.md
+++ b/_posts/2022-07-20-content-compass.md
@@ -7,6 +7,9 @@ authors:
 date: 2022-07-22
 categories:
  - intro
+
+meta_keywords: "data ingestion, ingestion, open source, opensearch, community, observability"
+meta_description: "Using OpenSearch to ingest community tag data helps us target learning material towards where knowledge gaps actually exist."
 ---
 
 I’m still tagging, and much like in my [last post](https://opensearch.org/blog/intro/2022/05/tag-youre-it/), I’ve been tagging forum threads in hopes of gaining insight into where to target content creation. What is most clear is the data showing that we definitely need more configuration, troubleshooting, and documentation material for OpenSearch and OpenSearch Dashboards in general (don’t forget to [file an issue](https://github.com/opensearch-project/documentation-website/issues/new/choose) for whatever you think is missing!)


### PR DESCRIPTION
Signed-off-by: Nate Boot <nateboot@amazon.com>

### Description
Alters `_includes/head.html` to include logic to use `meta_keywords` and `meta_description` as the page's meta keywords and meta description respectively. Blog publishers should be required to include these pieces of front matter going forward, without exception. 
 
### Issues Resolved
#1129 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
