### PR TITLE
Changing blog permalink structure, adding redirects from old urls via…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ defaults:
     scope:
       type: "posts"
     values:
-      permalink: blog/:categories/:year/:month/:title/
+      permalink: blog/:title/
 - 
     scope:
       path: ""

--- a/_posts/2019-09-10-Check-out-earlier-blogposts-on-Open-Distro-for-Elasticsearch.markdown
+++ b/_posts/2019-09-10-Check-out-earlier-blogposts-on-Open-Distro-for-Elasticsearch.markdown
@@ -8,6 +8,10 @@ odfeimport: true
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+
+redirect_from: /blog/odfe-updates/2019/09/Check-out-earlier-blogposts-on-Open-Distro-for-Elasticsearch/
+
+
 ---
 Hi Open Distro blog readers,
 

--- a/_posts/2019-09-11-Welcome-to-the-Open-Distro-for-Elasticsearch-Blog.markdown
+++ b/_posts/2019-09-11-Welcome-to-the-Open-Distro-for-Elasticsearch-Blog.markdown
@@ -9,6 +9,7 @@ odfeimport: true
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2019/09/Welcome-to-the-Open-Distro-for-Elasticsearch-Blog/"
 ---
 Welcome to the new Open Distro for Elasticsearch blog. Open Distro for Elasticsearch is an Apache 2.0-licensed distribution of Elasticsearch and Kibana. This blog will be a source for in-depth, technical content on the project. You’ll find how-tos, release notes, case studies, event announcements, and if you’re inspired, your own content, too! Or you can join the conversation by commenting on blog posts in the [discussion forum](https://discuss.opendistrocommunity.dev/).
 

--- a/_posts/2019-09-16-Open-Distro-for-Elasticsearch-1.2.0-released.markdown
+++ b/_posts/2019-09-16-Open-Distro-for-Elasticsearch-1.2.0-released.markdown
@@ -8,6 +8,8 @@ title: "Open Distro for Elasticsearch 1.2.0 Released"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+
+redirect_from: "/blog/odfe-updates/2019/09/Open-Distro-for-Elasticsearch-1.2.0-released/"
 ---
 
 Open Distro for Elasticsearch 1.2.0 is now available with new Linux tarball packages.

--- a/_posts/2019-10-30-Introducing-Root-Cause-Analysis-with-Open-Distro-for-Elasticsearch.markdown
+++ b/_posts/2019-10-30-Introducing-Root-Cause-Analysis-with-Open-Distro-for-Elasticsearch.markdown
@@ -10,6 +10,7 @@ title: "Introducing Root Cause Analysis with Open Distro for Elasticsearch"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2019/10/Introducing-Root-Cause-Analysis-with-Open-Distro-for-Elasticsearch/"
 ---
 If you’re interested in the operational behavior of your Elasticsearch cluster, then root cause analysis can help you identify fundamental issues that affect availability and performance of the cluster. Root cause analysis (RCA) is a problem solving technique used to examine symptoms of problems you’re interested in solving and to work backwards from those symptoms to the causes of the problems.
 

--- a/_posts/2019-11-04-Open-Distro-for-Elasticsearch-1.2.1-released.markdown
+++ b/_posts/2019-11-04-Open-Distro-for-Elasticsearch-1.2.1-released.markdown
@@ -8,6 +8,7 @@ title: "Open Distro for Elasticsearch 1.2.1 Released"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2019/11/Open-Distro-for-Elasticsearch-1.2.1-released/"
 ---
 
 Open Distro for Elasticsearch version 1.2.1 is available for download. 

--- a/_posts/2019-11-26-random-cut-forests.markdown
+++ b/_posts/2019-11-26-random-cut-forests.markdown
@@ -9,6 +9,7 @@ title: "Random Cut Forests"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2019/11/random-cut-forests/"
 ---
 We plan to publish a series of blogs discussing the science and math behind Random Cut Forests (RCF). In this first post we begin with a brief overview of Random Forests as a class of Machine Learning model. Next, we introduce RCFs and highlight their relevance to streaming data. Finally, we close with a look to the future, giving ideas for how RCFs support an Online Learning approach to a variety of statistical problems.
 

--- a/_posts/2019-11-26-real-time-anomaly-detection-in-open-distro-for-elasticsearch.markdown
+++ b/_posts/2019-11-26-real-time-anomaly-detection-in-open-distro-for-elasticsearch.markdown
@@ -8,6 +8,7 @@ title: "Real Time Anomaly Detection in Open Distro for Elasticsearch"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2019/11/real-time-anomaly-detection-in-open-distro-for-elasticsearch/"
 ---
 Today, we released Anomaly Detection (preview) on Open Distro for Elasticsearch. We are excited to continue our work on anomaly detection as a part of Open Distro for Elasticsearch in the coming months, and invite developers in the larger search community to join in and co-develop some parts. The feature includes a nice mix of machine learning algorithms, statistics methods, systems work, visualization and UI, and enterprise primitives (for working on anomalies).
 

--- a/_posts/2019-12-18-announcing-open-distro-for-elasticsearch-1-3-0-w-helm-chart-for-kubernetes-and-windows-support.markdown
+++ b/_posts/2019-12-18-announcing-open-distro-for-elasticsearch-1-3-0-w-helm-chart-for-kubernetes-and-windows-support.markdown
@@ -8,6 +8,7 @@ title: "Announcing Open Distro for Elasticsearch 1.3.0, Helm chart for Kubernete
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2019/12/announcing-open-distro-for-elasticsearch-1-3-0-w-helm-chart-for-kubernetes-and-windows-support/"
 ---
 We are pleased to announce the release of Open Distro for Elasticsearch 1.3.0.  Version 1.3.0 includes the upstream open source versions of Elasticsearch 7.3.2, Kibana 7.3.2 and the latest updates for the alerting, SQL, security, performance analyzer and Kibana plugins. We are excited to announce the general availability of Open Distro for Elasticsearch Index Management, installer for Windows deployments, Helm chart support for Kubernetes and cloud formation templates for Elasticsearch deployments. We would like to thank the community for their contributions and support that enabled us to release some of these new features.  Here are the full [release notes](https://discuss.opendistrocommunity.dev/t/open-distro-for-elasticsearch-1-3-0-released-with-helm-chart-for-kubernetes-and-windows-support/2028).
 

--- a/_posts/2019-12-19-real-time-root-cause-analysis-in-open-distro-for-elasticsearch.markdown
+++ b/_posts/2019-12-19-real-time-root-cause-analysis-in-open-distro-for-elasticsearch.markdown
@@ -12,6 +12,7 @@ title: "Real Time Root Cause Analysis in Open Distro for Elasticsearch"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2019/12/real-time-root-cause-analysis-in-open-distro-for-elasticsearch/"
 ---
 
 The Open Distro for Elasticsearch Performance Analyzer captures Elasticsearch and JVM activity, as well as lower-level resource usage (e.g. disk, network, CPU and memory) of these activities. Based on this instrumentation, Performance Analyzer computes and exposes diagnostic metrics, with the goal of enabling Elasticsearch users and administrators to measure and understand bottlenecks in their Elasticsearch clusters. The Open Distro for Elasticsearch PerfTop client provides real-time visualization of these diagnostic metrics to surface bottlenecks to Elasticsearch users and operators.

--- a/_posts/2020-02-11-Open-Distro-for-Elasticsearch-1.4.0-with-K-nearest-neighbor-(k-NN)-search-support-is-now-available.markdown
+++ b/_posts/2020-02-11-Open-Distro-for-Elasticsearch-1.4.0-with-K-nearest-neighbor-(k-NN)-search-support-is-now-available.markdown
@@ -8,6 +8,7 @@ odfeimport: true
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/02/Open-Distro-for-Elasticsearch-1.4.0-with-K-nearest-neighbor-(k-NN)-search-support-is-now-available/"
 ---
 We are happy to announce the release of Open Distro for Elasticsearch 1.4.0. Version 1.4.0 includes the upstream open source versions of Elasticsearch 7.4.2, Kibana 7.4.2 and the latest updates for the alerting, SQL, security, performance analyzer and Kibana plugins. We are also pleased to announce the general availability of Open Distro for Elasticsearch k-NN plugin, and installer for Windows deployments. We would like to thank the community for their contributions and support in testing out the new features.  Here are the full [release notes](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/opendistro-for-elasticsearch-release-notes-1.4.0.md). 
 

--- a/_posts/2020-04-02-Open-Distro-for-Elasticsearch-1.6.0-released.markdown
+++ b/_posts/2020-04-02-Open-Distro-for-Elasticsearch-1.6.0-released.markdown
@@ -8,6 +8,7 @@ title: "Open Distro for Elasticsearch 1.6.0 Released"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/04/Open-Distro-for-Elasticsearch-1.6.0-released/"
 ---
 
 

--- a/_posts/2020-04-06-Building-k-Nearest-Neighbor-(k-NN)-Similarity-Search-Engine-with-Elasticsearch.markdown
+++ b/_posts/2020-04-06-Building-k-Nearest-Neighbor-(k-NN)-Similarity-Search-Engine-with-Elasticsearch.markdown
@@ -11,6 +11,7 @@ title: "Build K-Nearest Neighbor (k-NN) Similarity Search Engine with Elasticsea
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/04/Building-k-Nearest-Neighbor-(k-NN)-Similarity-Search-Engine-with-Elasticsearch/"
 ---
 
 Recently, we launched k-NN similarity search feature on Open Distro for Elasticsearch. We are excited for the community to try out this feature and welcome you to come join in and contribute in building additional capabilities into Open Distro for Elasticsearch.

--- a/_posts/2020-04-16-The-Elasticsearch-Weight-Function.markdown
+++ b/_posts/2020-04-16-The-Elasticsearch-Weight-Function.markdown
@@ -9,6 +9,7 @@ title: "The Elasticsearch Weight Function"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/04/The-Elasticsearch-Weight-Function/"
 ---
 
 Distributed systems scale by coordinating and distributing their workloads horizontally, across several machines. In Elasticsearch, this is done by partitioning indexes into shards and distributing them across data nodes in the cluster.

--- a/_posts/2020-05-13-Open-Distro-for-Elasticsearch-1.7.0-released.markdown
+++ b/_posts/2020-05-13-Open-Distro-for-Elasticsearch-1.7.0-released.markdown
@@ -9,6 +9,7 @@ title: "Open Distro for Elasticsearch 1.7.0 Released"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/05/Open-Distro-for-Elasticsearch-1.7.0-released/"
 ---
 
 Open Distro for Elasticsearch 1.7.0 is now available for [download](https://opendistro.github.io/for-elasticsearch/downloads.html). [Upgrade to 1.7.0](https://opendistro.github.io/for-elasticsearch/downloads.html) to leverage the latest features and bug fixes.

--- a/_posts/2020-05-14-Real-time-Anomaly-Detection-is-now-available-in-Open-Distro-for-Elasticsearch-1.7.0.markdown
+++ b/_posts/2020-05-14-Real-time-Anomaly-Detection-is-now-available-in-Open-Distro-for-Elasticsearch-1.7.0.markdown
@@ -8,6 +8,7 @@ title: "Real-time Anomaly Detection is now available in Open Distro for Elastics
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/05/Real-time-Anomaly-Detection-is-now-available-in-Open-Distro-for-Elasticsearch-1.7.0/"
 ---
 
 We are excited to announce the general availability of real-time [anomaly detection](https://github.com/opendistro-for-elasticsearch/anomaly-detection) for streaming applications in this [release](https://opendistro.github.io/for-elasticsearch/blog/odfe-updates/2020/05/Open-Distro-for-Elasticsearch-1.7.0-released/). We would like to thank the community for their feedback on the preview release of the feature. The anomaly detection feature is built on [RCF](https://github.com/aws/random-cut-forest-by-aws) (Random Cut Forest), an unsupervised algorithm, that detects anomalies on live data and identifies issues as they evolve in real time. RCF is a proven algorithm built on years of academic and industry research. We are glad to announce the general availability of the open source RCF libraries for the greater benefit of our data science community. 

--- a/_posts/2020-05-15-Index-State-Management-in-Open-Distro-for-Elasticsearch.markdown
+++ b/_posts/2020-05-15-Index-State-Management-in-Open-Distro-for-Elasticsearch.markdown
@@ -8,6 +8,7 @@ title: "Index State Management in Open Distro for Elasticsearch"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/05/Index-State-Management-in-Open-Distro-for-Elasticsearch/"
 ---
 
 Elasticsearch is an open source distributed search and analytics engine based on [Apache Lucene](https://lucene.apache.org/). After adding your data to Elasticsearch, you can perform full-text searches on the data with all of the features you may expect: search by field, search multiple indices, boost fields, rank results by score, sort results by field, and aggregate results. You can also use [Kibana](https://opendistro.github.io/for-elasticsearch-docs/docs/kibana/) to build visualizations for data in Elasticsearch.

--- a/_posts/2020-06-02-Open-Distro-for-Elasticsearch-1.8.0-is-released-supports-Cosine-Similarity-in-k-NN.markdown
+++ b/_posts/2020-06-02-Open-Distro-for-Elasticsearch-1.8.0-is-released-supports-Cosine-Similarity-in-k-NN.markdown
@@ -10,6 +10,7 @@ title: "Open Distro for Elasticsearch 1.8.0 is released, supports Cosine Similar
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/06/Open-Distro-for-Elasticsearch-1.8.0-is-released-supports-Cosine-Similarity-in-k-NN/"
 ---
 
 We are pleased to announce the release for Open Distro for Elasticsearch 1.8.0. that now supports cosine similarity distance metric with k-NN. We released k-NN similarity search feature in Open Distro for Elasticsearch 1.4.0 with support for Euclidean distance to calculate similarity between the vectors. With cosine similarity, you can now measure the orientation between two vectors while Euclidean distance is used to measure the magnitude. We would also like to thank our community for contributing snapshot support in Index Management. This feature enables users to define snapshot action in Index State Management for retention and to migrate indices from one cluster to another. Open Distro for Elasticsearch 1.8.0 can be downloaded [here](https://opendistro.github.io/for-elasticsearch/downloads.html).

--- a/_posts/2020-06-12-An-overview-of-the-SQL-Engine-in-Open-Distro-for-Elasticsearch.markdown
+++ b/_posts/2020-06-12-An-overview-of-the-SQL-Engine-in-Open-Distro-for-Elasticsearch.markdown
@@ -8,6 +8,7 @@ title: "An overview of the SQL Engine in Open Distro for Elasticsearch"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/06/An-overview-of-the-SQL-Engine-in-Open-Distro-for-Elasticsearch/"
 ---
 Open Distro for Elasticsearch is a popular choice for use cases such as log analytics, search, real-time application monitoring and click-stream analysis and more. One commonality among the various use cases is the need to write and run queries to obtain search results at lightning speed, and that in turn, requires the user to have expertise in the JSON based Elasticsearch query domain-specific language (Query DSL). Although Query DSL is powerful, it has a steep learning curve, and was not designed as a human interface to easily create ad hoc queries and explore user data. In order to solve this problem, we provided a SQL engine with Open Distro for Elasticsearch, which we have been expanding since the initial release. As part of this continued investment, we are happy to announce new capabilities we are adding including a Kibana-based SQL Workbench and a new SQL CLI that will make it easier than ever for Open Distro for Elasticsearch users to use the SQL engine to work with their data.
 

--- a/_posts/2020-07-09-Introducing-Real-Time-Root-Cause-Analysis-Engine-in-Elasticsearch.md
+++ b/_posts/2020-07-09-Introducing-Real-Time-Root-Cause-Analysis-Engine-in-Elasticsearch.md
@@ -14,6 +14,7 @@ title: "Introducing real-time Root Cause Analysis Engine in Elasticsearch "
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/07/Introducing-Real-Time-Root-Cause-Analysis-Engine-in-Elasticsearch/"
 ---
 
 We are excited to release the real-time Root Cause Analysis engine for Elasticsearch in 

--- a/_posts/2020-07-09-Open-Distro-for-Elasticsearch-1.9.0-is-released.markdown
+++ b/_posts/2020-07-09-Open-Distro-for-Elasticsearch-1.9.0-is-released.markdown
@@ -8,6 +8,7 @@ title: "Open Distro for Elasticsearch 1.9.0 is now available"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/07/Open-Distro-for-Elasticsearch-1.9.0-is-released/"
 ---
 We are pleased to announce the release for [Open Distro for Elasticsearch 1.9.0](https://opendistro.github.io/for-elasticsearch/downloads.html) that introduces [Root Cause Analysis Engine in Performance Analyzer](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca), batch actions like [start, stop](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/195) and [delete](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/204) for anomaly detectors in Anomaly Detection, [support for remote cluster indexes](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/244) in Anomaly Detection, and an ability to [set index priority action](https://github.com/opendistro-for-elasticsearch/index-management/pull/241) in Index State Management feature. Open Distro for Elasticsearch 1.9.0 can be downloaded [here](https://opendistro.github.io/for-elasticsearch/downloads.html).
 

--- a/_posts/2020-07-29-Open-Distro-for-Elasticsearch-now-supports-integration-with-Tableau-and-Microsoft-Excel.markdown
+++ b/_posts/2020-07-29-Open-Distro-for-Elasticsearch-now-supports-integration-with-Tableau-and-Microsoft-Excel.markdown
@@ -9,6 +9,7 @@ title: "Open Distro for Elasticsearch now Supports integration with Tableau and 
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/07/Open-Distro-for-Elasticsearch-now-supports-integration-with-Tableau-and-Microsoft-Excel/"
 ---
 
 We now facilitate connecting Elasticsearch with two of the most powerful business intelligence and data visualization applications, Tableau and Microsoft Excel. To achieve this, we introduce the Open Distro for Elastic Search - Tableau integration and the Open Distro for Elastic Search - Excel integration in Open Distro for Elasticsearch SQL Engine . 

--- a/_posts/2020-09-30-Open-Distro-for-Elasticsearch-1.10.1-is-released.md
+++ b/_posts/2020-09-30-Open-Distro-for-Elasticsearch-1.10.1-is-released.md
@@ -8,6 +8,7 @@ title: "Open Distro for Elasticsearch 1.10.1 is now available"
 categories:
 - odfe-updates
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/odfe-updates/2020/09/Open-Distro-for-Elasticsearch-1.10.1-is-released/"
 ---
 We are pleased to announce the release of [Open Distro for Elasticsearch 1.10.1](https://opendistro.github.io/for-elasticsearch/downloads.html). With this release we are adding support for several new features including a new [command line interface](https://github.com/opendistro-for-elasticsearch/anomaly-detection/tree/master/cli) and [sample data](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/272) for Anomaly Detection, an [email destination](https://github.com/opendistro-for-elasticsearch/alerting/pull/244) in Alerting, a [warmup API](https://github.com/opendistro-for-elasticsearch/k-NN#warmup-api) in k-NN, and an overhauled Kibana plugin for Security. Open Distro for Elasticsearch 1.10.1 and Open Distro for Elasticsearch Kibana 1.10.1 can be downloaded [here](https://opendistro.github.io/for-elasticsearch/downloads.html).
 

--- a/_posts/2020-10-09-developer-advocacy-with-open-distro.markdown
+++ b/_posts/2020-10-09-developer-advocacy-with-open-distro.markdown
@@ -8,6 +8,7 @@ title: "Developer Advocacy with Open Distro for Elasticsearch"
 categories:
 - community-updates
 feature_image: "/for-elasticsearch/assets/media/blog-images/community-addition.png"
+redirect_from: "/blog/community-updates/2020/10/developer-advocacy-with-open-distro/"
 ---
 
 While Open Distro for Elasticsearch is an open-source, community-led project, we are gaining another full-time person devoted to the project ([me](https://linkedin.com/in/kyle-davis-search)). Before I start contributing and interacting with the community, I wanted to take the time to introduce the role and myself.

--- a/_posts/2020-10-13-community-meeting.markdown
+++ b/_posts/2020-10-13-community-meeting.markdown
@@ -8,6 +8,7 @@ title: "Late October Community Meeting"
 categories:
 - meetings
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/meetings/2020/10/community-meeting/"
 ---
 
 Join us on Monday, October 19th at 10am Pacific (UTC-7) on [Zoom](https://www.meetup.com/OpenSearch/events/thmcwrybcnbzb/) for our biweekly community meeting.

--- a/_posts/2020-10-26-community-meeting-early-nov.markdown
+++ b/_posts/2020-10-26-community-meeting-early-nov.markdown
@@ -8,6 +8,7 @@ title: "Early November Community Meeting"
 categories:
 - meetings
 feature_image: "https://d2908q01vomqb2.cloudfront.net/ca3512f4dfa95a03169c5a670a4c91a19b3077b4/2019/03/26/open_disto-elasticsearch-logo-800x400.jpg"
+redirect_from: "/blog/meetings/2020/10/community-meeting-early-nov/"
 ---
 
 We've got a jam-packed agenda for this biweekly community meeting! Join us on Monday, November 2nd at 10am Pacific (UTC-7) on [Zoom](https://www.meetup.com/OpenSearch/events/thmcwrybcpbdb/). Our focus topics will include:

--- a/_posts/2020-10-27-fine-grained-access-control-for-search.md
+++ b/_posts/2020-10-27-fine-grained-access-control-for-search.md
@@ -8,6 +8,7 @@ title: "Using fine grained access control for search"
 categories:
 - technical-posts
 feature_image: "/assets/media/blog-images/2020-10-27-fine-grained-access-control-for-search/fgac-fields.png"
+redirect_from: "/blog/technical-posts/2020/10/fine-grained-access-control-for-search/"
 ---
 
 Open Distro for Elasticsearch has extensive access control capabilities built right in. Of course, access control can prevent access to sensitive information, but it can also help you build applications that depend on Open Distro for Elasticsearch for search. Let’s explore this a little more.

--- a/_posts/2021-04-12-journey.markdown
+++ b/_posts/2021-04-12-journey.markdown
@@ -6,6 +6,7 @@ authors:
 
 date:   2021-04-12 01:01:01 -0700
 categories: update
+redirect_from: "/blog/update/2021/04/journey/"
 ---
 
 Welcome to OpenSearch news. In this section we plan to update the community on new developments and call attention to great things happening around OpenSearch.

--- a/_posts/2021-05-13-opensearch-beta-announcement.markdown
+++ b/_posts/2021-05-13-opensearch-beta-announcement.markdown
@@ -6,6 +6,7 @@ authors:
   - kyledvs
 date:   2021-05-13 01:01:01 -0700
 categories: update
+redirect_from: "/blog/update/2021/05/opensearch-beta-announcement/"
 ---
 
 We are excited to release the OpenSearch Beta 1.0 (derived from Elasticsearch 7.10.2) and OpenSearch Dashboards Beta 1.0 (derived from Kibana 7.10.2). With this beta release, we have refactored all the Open Distro for Elasticsearch plugins to work with OpenSearch and provide the community with [downloadable artifacts (Linux tars and Docker images)](/downloads.html) to run OpenSearch and OpenSearch Dashboards with these plugins installed. Features released with this beta include;

--- a/_posts/2021-05-26-opensearch-roadmap-announcement.markdown
+++ b/_posts/2021-05-26-opensearch-roadmap-announcement.markdown
@@ -5,6 +5,7 @@ authors:
   - elifish
 date:   2021-05-25 01:01:01 -0700
 categories: update
+redirect_from: "/blog/update/2021/05/opensearch-roadmap-announcement/"
 ---
 
 I wanted to share that a new public roadmap was published to the OpenSearch [project’s GitHub](https://github.com/orgs/opensearch-project/projects/1). The roadmap shows the next several months of planned features and releases. Going forward, this roadmap will show what the maintainers and contributors of the various components of the project intend to work on and when that work aims to launch.

--- a/_posts/2021-05-28-community-meeting.markdown
+++ b/_posts/2021-05-28-community-meeting.markdown
@@ -5,6 +5,8 @@ authors:
   - kyledvs
 date:   2021-05-28 01:01:01 -0700
 categories: meetings
+redirect_from: "/blog/meetings/2021/05/community-meeting/"
+
 ---
 
 You are welcome to join us for the biweekly [OpenSearch community meeting on Tuesday, June 1st](https://opensearch.org/events/2021-early-june/). In this meeting we’re going to try out a collaborative agenda, check out the event page for details and links.

--- a/_posts/2021-06-03-my-first-steps-in-opensearch-plugins.markdown
+++ b/_posts/2021-06-03-my-first-steps-in-opensearch-plugins.markdown
@@ -8,6 +8,7 @@ categories:
 - technical-posts
 feature_image: "/assets/media/blog-images/2021-06-03-my-first-steps-in-opensearch-plugins/my-first-steps-in-plugins-feature-image.jpg"
 canonical: https://logz.io/blog/opensearch-plugins
+redirect_from: "/blog/technical-posts/2021/06/my-first-steps-in-opensearch-plugins/"
 ---
 
 ### Taking the leap, not the _plunge_

--- a/_posts/2021-06-07-opensearch-release-candidate-announcement.markdown
+++ b/_posts/2021-06-07-opensearch-release-candidate-announcement.markdown
@@ -5,6 +5,7 @@ authors:
   - andhopp
 date:   2021-06-07
 categories: update
+redirect_from: "/blog/update/2021/06/opensearch-release-candidate-announcement/"
 ---
 
 Today I am excited to announce the Release Candidate (RC1) for version 1.0.0 of both OpenSearch (derived from Elasticsearch 7.10.2) and OpenSearch Dashboards (derived from Kibana 7.10.2). The Release Candidate includes downloadable [artifacts](https://opensearch.org/downloads.html) (Linux tars and Docker images) as well as a number of OpenSearch plugins (listed below). 

--- a/_posts/2021-06-09-opensearch-backwards-compatibility-faq.markdown
+++ b/_posts/2021-06-09-opensearch-backwards-compatibility-faq.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-posts
 twittercard:
   description: "In introducing OpenSearch we said: \"The Amazon OpenSearch Service APIs will be backwards compatible with the existing service APIs to eliminate any need for customers to update their current client code or applications. Additionally, just as we did for previous versions of Elasticsearch, we will provide a seamless upgrade path from existing Elasticsearch 6.x and 7.x managed clusters to OpenSearch.\"... "
+redirect_from: "/blog/technical-posts/2021/06/opensearch-backwards-compatibility-faq/"
 ---
 In [introducing OpenSearch](https://aws.amazon.com/blogs/opensource/introducing-opensearch/) we said:
 > The Amazon OpenSearch Service APIs will be backwards compatible with the existing service APIs to eliminate any need for customers to update their current client code or applications. Additionally, just as we did for previous versions of Elasticsearch, we will provide a seamless upgrade path from existing Elasticsearch 6.x and 7.x managed clusters to OpenSearch.

--- a/_posts/2021-06-21-data-into-opensearch.markdown
+++ b/_posts/2021-06-21-data-into-opensearch.markdown
@@ -9,6 +9,7 @@ categories:
   - community
 twittercard:
   description: "In introducing OpenSearch we said: \"The Amazon OpenSearch Service APIs will be backwards compatible with the existing service APIs to eliminate any need for customers to update their current client code or applications. Additionally, just as we did for previous versions of Elasticsearch, we will provide a seamless upgrade path from existing Elasticsearch 6.x and 7.x managed clusters to OpenSearch.\"... "
+redirect_from: "/blog/community/2021/06/data-into-opensearch/"
 ---
 
 I expect very few people will *only* use OpenSearch and OpenSearch Dashboards. Sure, you might do a little testing with the sample data in OpenSearch Dashboards, but really you’re going to be using something to help you get some data into that cluster. There is a ton of existing, compatible software that can help you do just that - agents, client libraries for programming languages, and data pipeline tools. 

--- a/_posts/2021-06-29-feature-highlight-reporting.markdown
+++ b/_posts/2021-06-29-feature-highlight-reporting.markdown
@@ -6,6 +6,7 @@ authors:
   - elifish
 date:   2021-06-29 01:01:01 -0700
 categories: feature
+redirect_from: "/blog/feature/2021/06/feature-highlight-reporting/"
 ---
 
 The OpenSearch [Reporting](https://github.com/opensearch-project/dashboards-reports) feature helps users generate reports from Dashboards, Visualizations, and the Discover panel and export them to PDF, PNG, and CSV file formats to easily share. In this blog post we talk about how to use the reporting feature, how it is implemented and how it was built with numerous contributions from the open source community. Last, we discuss future plans to improve it.

--- a/_posts/2021-06-30-introducing-community-projects.md
+++ b/_posts/2021-06-30-introducing-community-projects.md
@@ -8,6 +8,7 @@ categories:
   - community
 twittercard:
   description: "Many open source projects benefit from the ecosystem of software created on top of or for the project. As a first steps towards having a robust ecosystem, opensearch.org now has added a community projects page to highlight projects created for the OpenSearch community by the OpenSearch community... "
+redirect_from: "/blog/community/2021/06/introducing-community-projects/"
 ---
 
 Many open source projects benefit from the ecosystem of software created on top of or for the project. As an example, the Node Package Manager (NPM) makes JavaScript more approachable. It hosts a variety of modules that solve problems people face during the development of JavaScript software. Users can quickly search for these modules install them and incorporate them directly into their JavaScript project. Having a similar ecosystem for OpenSearch will help all of us get more out of our own OpenSearch deployments. As a first step, I wanted to share that [opensearch.org](/) now has a [community projects page](/community_projects/). The goal of this page is to highlight projects built by the OpenSearch community for the OpenSearch community.

--- a/_posts/2021-07-08-how-to-upgrade-from-opendistro-to-opensearch.markdown
+++ b/_posts/2021-07-08-how-to-upgrade-from-opendistro-to-opensearch.markdown
@@ -9,6 +9,7 @@ categories:
   - technical-posts
 twittercard:
   description: "As general availability for OpenSearch and OpenSearch Dashboards is fast approaching, we wanted to provide some guidance on upgrading Open Distro for Elasticsearch (Open Distro) 1.13 to the OpenSearch 1.0 as well as some step to help you prepare.\"... "
+redirect_from: "/blog/technical-posts/2021/07/how-to-upgrade-from-opendistro-to-opensearch/"
 ---
 As general availability for OpenSearch and OpenSearch Dashboards is fast approaching, we wanted to provide some guidance on upgrading Open Distro for Elasticsearch (Open Distro) 1.13 to OpenSearch 1.0, along with some steps to help you prepare for the upgrade. While most of you will already have the experience of upgrading Elasticsearch clusters, we wanted to provide a refresher on the upgrade process, and make some specific call-outs regard the upgrade to OpenSearch from Open Distro.
 

--- a/_posts/2021-07-12-opensearch-general-availability-announcement.markdown
+++ b/_posts/2021-07-12-opensearch-general-availability-announcement.markdown
@@ -11,6 +11,7 @@ categories:
   - updates
 twittercard:
   description: "Today is a really good day for the OpenSearch project. Since its start, the goal has been to quickly produce a version of OpenSearch that's ready to use in production environments. After a ton of work by the OpenSearch community, we’re thrilled to announce the first general availability (GA) release of OpenSearch 1.0. Everyone in this highly-engaged and diverse community should be proud of the accomplishment in reaching this milestone together."
+redirect_from: "/blog/updates/2021/07/opensearch-general-availability-announcement/"
 ---
 
 Today is a really good day for the OpenSearch project. Since its start, the goal has been to quickly produce a version of OpenSearch that's ready to use in production environments. After a ton of work by the OpenSearch community, we’re thrilled to announce the first general availability (GA) release of OpenSearch 1.0. Everyone in this highly-engaged and diverse community should be proud of the accomplishment in reaching this milestone together.

--- a/_posts/2021-07-26-feature-highlight-opensearch-dashboards-notebooks.markdown
+++ b/_posts/2021-07-26-feature-highlight-opensearch-dashboards-notebooks.markdown
@@ -8,6 +8,7 @@ authors:
   - elifish
 date:   2021-07-26 01:01:01 -0700
 categories: feature
+redirect_from: "/blog/feature/2021/07/feature-highlight-opensearch-dashboards-notebooks/"
 ---
 
 OpenSearch Dashboards [Notebooks](https://opensearch.org/docs/dashboards/notebooks/) lets you easily combine live visualizations, narrative text, and SQL and [Piped Processing Language (PPL)](https://opensearch.org/docs/search-plugins/ppl/index/) queries so that you can tell your data’s story. You can interactively explore data by running different visualizations and share them with team members to collaborate. Notebooks can help with a variety of use cases such as creating postmortem reports, designing operations run books, building live infrastructure reports, and even documentation.  With OpenSearch 1.0, Notebooks is now production ready. Additionally, multiple enhancements were introduced such as support for multi-tenancy, query languages like SQL and PPL and an integration with reporting.

--- a/_posts/2021-08-02-streaming-analytics.markdown
+++ b/_posts/2021-08-02-streaming-analytics.markdown
@@ -6,6 +6,7 @@ authors:
   - joshtok
 date:   2021-08-02 01:01:01 -0700
 categories: feature
+redirect_from: "/blog/feature/2021/08/streaming-analytics/"
 ---
 
 

--- a/_posts/2021-08-03-community-clients.markdown
+++ b/_posts/2021-08-03-community-clients.markdown
@@ -6,6 +6,7 @@ authors:
 date:   2021-08-11 01:01:01 -0700
 categories: 
   - community
+redirect_from: "/blog/community/2021/08/community-clients/"
 ---
 
 _Note: This post was updated in Dec 2021 to reflect the current status of the new clients._

--- a/_posts/2021-08-24-partner-highlight-titaniam.markdown
+++ b/_posts/2021-08-24-partner-highlight-titaniam.markdown
@@ -6,6 +6,7 @@ authors:
 date:   2021-08-24 01:01:01 -0700
 categories: 
   - partners
+redirect_from: "/blog/partners/2021/08/partner-highlight-titaniam/"
 ---
 
 Over the past few years there have been [numerous security breaches](https://en.wikipedia.org/wiki/List_of_data_breaches) reported in the news. These types of incidents are top of mind as people want to ensure the software and services they build are secure. OpenSearch provides an out-of-the-box security plugin so that developers can build OpenSearch deployments securely. The out-of-the-box [features](https://opensearch.org/docs/security-plugin/index/) include:

--- a/_posts/2021-08-27-what-is-semver.markdown
+++ b/_posts/2021-08-27-what-is-semver.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "I think people often use Semantic Versioning (a.k.a SemVer) intuitively even if they don't know the term. So, let's take a look at what SemVer is and what it means for software like OpenSearch."
+redirect_from: "/blog/technical-post/2021/08/what-is-semver/"
 ---
 
 I think people often use Semantic Versioning (a.k.a SemVer) intuitively even if they don't know the term. So, let's take a look at what SemVer is and what it means for software like OpenSearch.

--- a/_posts/2021-09-01-a-query-or-there-and-back-again.md
+++ b/_posts/2021-09-01-a-query-or-there-and-back-again.md
@@ -7,6 +7,7 @@ authors:
 date: 2021-09-02 01:01:01 -0700
 categories:
   - community
+redirect_from: "/blog/community/2021/09/a-query-or-there-and-back-again/"
 ---
 
 OpenSearch is a distributed, open source search and analytics suite used for a broad set of use cases like real-time application monitoring, log analytics, and website search. And it's easy to imagine why you might want to query information from OpenSearch in those use cases. But you might not know how those queries actually work. Well, that’s what we’re going to explore in this blog! In particular, we’re going to take a closer look at how a query works by following a query through OpenSearch. 

--- a/_posts/2021-09-16-data-prepper-roadmap.markdown
+++ b/_posts/2021-09-16-data-prepper-roadmap.markdown
@@ -9,6 +9,7 @@ categories:
   - releases
 twittercard:
   description: "Today is an exciting day! The roadmap for Data Prepper is now publicly available. Data Prepper is a component of OpenSearch that accepts, filters, transforms, enriches, and routes data at scale."
+redirect_from: "/blog/releases/2021/09/data-prepper-roadmap/"
 ---
 
 *This blog has been updated for technical accuracy on 17 Nov 2022.*

--- a/_posts/2021-09-30-opensearch-py-js-go.markdown
+++ b/_posts/2021-09-30-opensearch-py-js-go.markdown
@@ -8,6 +8,7 @@ categories:
   - community
 twittercard:
   description: "Last month, the project announced the intention to release OpenSearch specific clients and today the first batch are ready for production use. You can get opensearch-py from PyPI, install opensearch-js from npm and start using opensearch-go."
+redirect_from: "/blog/community/2021/09/opensearch-py-js-go/"
 ---
 
 Last month, the [project announced the intention to release OpenSearch specific clients](https://opensearch.org/blog/community/2021/08/community-clients/) and today the first batch are ready for production use. You can get [opensearch-py from PyPI](https://pypi.org/project/opensearch-py/), install [opensearch-js from npm](https://www.npmjs.com/package/@opensearch-project/opensearch) and start using [opensearch-go](https://github.com/opensearch-project/opensearch-go).

--- a/_posts/2021-10-04-building-opensearch-1-1-distributions.markdown
+++ b/_posts/2021-10-04-building-opensearch-1-1-distributions.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "This post details how the OpenSearch project produces reliable and repeatable distributions."
+redirect_from: "/blog/technical-post/2021/10/building-opensearch-1-1-distributions/"
 ---
 The Open Distro for Elasticsearch was a package containing open source Elasticsearch and a dozen open source plugins. Open Distro's release process began by picking up a stable version of Elasticsearch OSS, incrementing all the plugin version numbers, and going through a development cycle. Plugins went from `-SNAPSHOT` to `-beta`, then `-rc`, then finally to a release.
 

--- a/_posts/2021-10-05-Launch-Announcement-1-1.markdown
+++ b/_posts/2021-10-05-Launch-Announcement-1-1.markdown
@@ -11,6 +11,7 @@ category:
 - releases
 twittercard:
   description: "We are excited to announce the 1.1.0 release of OpenSearch, OpenSearch Dashboards, and the OpenSearch Project plugins"
+redirect_from: "/blog/releases/2021/10/Launch-Announcement-1-1/"
 ---
 
 We are excited to announce the 1.1.0 release of OpenSearch, OpenSearch Dashboards, and the OpenSearch Project plugins (available to [download](https://opensearch.org/versions/opensearch-1-1-0.html) today). 

--- a/_posts/2021-10-11-opensearch-security-concepts.markdown
+++ b/_posts/2021-10-11-opensearch-security-concepts.markdown
@@ -12,6 +12,7 @@ twittercard:
   account: "@eliatra_ire"
   description: "OpenSearch provides a strong and reliable security model out-of-the-box. This post explains some of the core concepts of OpenSearch security."
   image: "/assets/media/blog-images/2021-10-11-opensearch-security-concepts/tls_encryption.png"
+redirect_from: "/blog/technical-posts/2021/10/opensearch-security-concepts/"
 ---
 
 [Eliatra](https://eliatra.com/){:target="_blank"} provides OpenSearch Support, Professional Services and Custom Feature Development. Our team has been working with open source search engine technology like Lucene and Elastic products since the very beginning. We have extensive ecosystem knowledge. This makes us the perfect partner for AWS and OpenSearch, not only as a contributor but also to offer full support and professional services.

--- a/_posts/2021-10-12-cross-cluster-replication-intro.markdown
+++ b/_posts/2021-10-12-cross-cluster-replication-intro.markdown
@@ -10,6 +10,7 @@ categories:
   - cross-cluster
 twittercard:
   description: "Cross-cluster replication allows you to replicate indices from one cluster to another. This post provides a brief overview of the feature and the thought process behind the design and implementation."
+redirect_from: "/blog/cross-cluster/2021/10/cross-cluster-replication-intro/"
 ---
 
 Earlier this year while working on Open Distro the team announced the [experimental release of cross-cluster replication](https://opendistro.github.io/for-elasticsearch/blog/releases/2021/02/announcing-ccr/). I am happy to announce the general availability of cross-cluster replication for OpenSearch. This post provides a brief overview of the feature and the thought process behind the design and implementation.

--- a/_posts/2021-10-14-partner-highlight-aiven.md
+++ b/_posts/2021-10-14-partner-highlight-aiven.md
@@ -8,6 +8,7 @@ categories:
   - partners
 twittercard:
   description: "Aiven announces OpenSearch as the newest addition to their cloud data platform. This reinforces their commitment to Open Source, reflects their ongoing contributions in the OpenSearch project, and ensures a smooth upgrade path for customers using open source Elasticsearch"
+redirect_from: "/blog/partners/2021/10/partner-highlight-aiven/"
 ---
 [Aiven](https://aiven.io) has recently [announced](https://aiven.io/blog/announcing-aiven-for-opensearch) Aiven for OpenSearch as the newest addition to their managed database services platform. As an existing provider of open source Elasticsearch as a service, the move to OpenSearch was a logical next step. Customers can stay with Aiven and have an open source upgrade path ahead of them with easy migration of existing Elasticsearch services to Aiven for OpenSearch.
 

--- a/_posts/2021-10-20-alerting-intro.md
+++ b/_posts/2021-10-20-alerting-intro.md
@@ -10,6 +10,7 @@ categories:
   - partners
 twittercard:
   description: "Log analytics is a popular use case for OpenSearch. Alerting can help you by automatically detecting problems from your ingested logs. In this blog we walk through creating alerts and how they work."
+redirect_from: "/blog/partners/2021/10/alerting-intro/"
 ---
 
 Log analytics has grown to be one of OpenSearch’s popular use cases as it is able to easily ingest, secure, search, visualize, and analyze log data. The automated [alerting feature](https://opensearch.org/docs/latest/monitoring-plugins/alerting/index/) can further help you by automatically detecting problems from your ingested data. When a problem is detected, you can send an alert to external systems like Slack, email, and more. For example, you might want to create an alert and notify a Slack channel if your application logs see more than five HTTP 503 errors within an hour. In this blog we walk through setting up an alerting policy and discuss how the [alerting plugin](https://opensearch.org/docs/monitoring-plugins/alerting/index/) works.

--- a/_posts/2021-10-29-moving-from-opensource-elasticsearch-to-opensearch.markdown
+++ b/_posts/2021-10-29-moving-from-opensource-elasticsearch-to-opensearch.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-posts
 twittercard:
   description: "Learn how to move from open source Elasticsearch to OpenSearch, and why you want to move now."
+redirect_from: "/blog/technical-posts/2021/10/moving-from-opensource-elasticsearch-to-opensearch/"
 ---
 *Blog refreshed for technical accuracy on 16 Nov 2022*
 

--- a/_posts/2021-11-05-bwc-testing-for-opensearch.markdown
+++ b/_posts/2021-11-05-bwc-testing-for-opensearch.markdown
@@ -9,6 +9,7 @@ categories:
   - technical-post
 twittercard:
   description: "This post provides details on the framework in OpenSearch for backwards compatibility testing."
+redirect_from: "/blog/technical-post/2021/11/bwc-testing-for-opensearch/"
 ---
 
 Backwards Compatibility (BWC) testing is used to test and determine the safe upgrade paths from a supported BWC version to the current version. The framework in OpenSearch allows you to run these BWC tests for all supported BWC versions in OpenSearch allowing safe upgrade paths between versions. This framework is now extended to work for plugins which can introduce their BWC tests without creating individual frameworks of their own. This post provides details on the framework in OpenSearch for backwards compatibility.

--- a/_posts/2021-11-12-partner-highlight-instaclustr.md
+++ b/_posts/2021-11-12-partner-highlight-instaclustr.md
@@ -8,6 +8,7 @@ categories:
   - partners
 twittercard:
     description: "@Instaclustr is excited to welcome #OpenSearch as another key open source technology to their suite of managed service offerings!"
+redirect_from: "/blog/partners/2021/11/partner-highlight-instaclustr/"
 ---
 
 [Instaclustr](https://www.instaclustr.com) is pleased to announce the general availability of OpenSearch and OpenSearch Dashboards on the Instaclustr SaaS Platform. OpenSearch is another key open source technology that joins our suite of managed offerings.  Instaclustr also provides Enterprise Support for organizations who choose to run OpenSearch themselves.

--- a/_posts/2021-11-18-real-time-and-historical-ad.markdown
+++ b/_posts/2021-11-18-real-time-and-historical-ad.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "You can leverage anomaly detection to analyze vast amount of logs in many different ways. Some analytics approaches require real-time detection, such as application monitoring, event detection, and fraud detection. "
+redirect_from: "/blog/technical-post/2021/11/real-time-and-historical-ad/"
 ---
 
 You can leverage anomaly detection to analyze vast amount of logs in many different ways. Some analytics approaches require real-time detection, such as application monitoring, event detection, and fraud detection. Others involve analyzing past data to identify the trends and patterns, isolate the root cause and prevent them from happening again in the future. The anomaly detection plugin in OpenSearch already supports real-time streaming data. In OpenSearch 1.1.0, the team introduced support for anomaly detection on historical data. Often-times, the historical and real-time use cases work hand-in-hand. You may find real-time anomalies in your data, and decide to run historical detection to search for similar patterns in the past. Or, you may first search for anomalies in the past data, then decide to configure anomaly detection to monitor your system for anomalies in real-time. OpenSearch 1.1.0 also streamlines the anomaly detection configuration with the new unified flow that allows you to configure an anomaly detector once that can then be applied to both real-time or historical analysis. In this blog, I will review each of the steps in the unified workflow with an example.

--- a/_posts/2021-11-22-launch-announcement-1-2-0.markdown
+++ b/_posts/2021-11-22-launch-announcement-1-2-0.markdown
@@ -8,6 +8,7 @@ categories:
   - releases
 twittercard:
     description: "With this latest version of the OpenSearch distribution (OpenSearch, OpenSearch Dashboards, as well as plugins and tools) you can enjoy a number of new features and enhancements as well as improvements to stability and efficiency."
+redirect_from: "/blog/releases/2021/11/launch-announcement-1-2-0/"
 ---
 
 

--- a/_posts/2021-11-24-setup-multinode-cluster-kubernetes.markdown
+++ b/_posts/2021-11-24-setup-multinode-cluster-kubernetes.markdown
@@ -10,6 +10,7 @@ excerpt: |
   OpenSearch can operate as a single-node or multi-node cluster. Production setup typically requires a multi-node cluster. In this tutorial, you will learn how to setup a multi-node cluster of OpenSearch using Helm and configure OpenSearch Dashboards to access the cluster. This will setup a  three-node cluster that has one dedicated master node, one dedicated coordinating node, and one data node that are used for ingesting data. So, let’s start setting up the OpenSearch stack on K8s.
 twittercard:
   description: "Setup OpenSearch multi-node cluster on Kubernetes using Helm Charts."
+redirect_from: "/blog/technical-posts/2021/11/setup-multinode-cluster-kubernetes/"
 ---
 
 ### Introduction

--- a/_posts/2021-12-01-plugins-intro.markdown
+++ b/_posts/2021-12-01-plugins-intro.markdown
@@ -9,6 +9,7 @@ categories:
   - technical-post
 twittercard:
   description: "OpenSearch enables enhancing core features in a custom way via Plugins. In this blog post we wanted to unbox how plugins load, install, and run in OpenSearch..."
+redirect_from: "/blog/technical-post/2021/12/plugins-intro/"
 ---
 
 OpenSearch enables enhancing core features in a custom way via plugins. For example, plugins could add custom mapping types, engine scripts, etc. In this blog post we wanted to unbox how plugins load, install, and run in OpenSearch.

--- a/_posts/2021-12-07-distributed-tracing-pipeline-with-opentelemetry.md
+++ b/_posts/2021-12-07-distributed-tracing-pipeline-with-opentelemetry.md
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "Over the past few years, the importance of observability when developing and managing applications has spiked with the spotlight firmly on micro-services, service mesh. Distributed services can be unpredictable. Despite our best efforts, failures and performance bottlenecks in such systems are inevitable and difficult to isolate. In such an environment, having deep visibility into the behavior of your applications is critical for software development teams and operators."
+redirect_from: "/blog/technical-post/2021/12/distributed-tracing-pipeline-with-opentelemetry/"
 ---
 
 Over the past few years, the importance of observability when developing and managing applications has spiked with the spotlight firmly on micro-services, service mesh. Distributed services can be unpredictable. Despite our best efforts, failures and performance bottlenecks in such systems are inevitable and difficult to isolate. In such an environment, having deep visibility into the behavior of your applications is critical for software development teams and operators.

--- a/_posts/2021-12-08-introducing-opensearch-benchmark.md
+++ b/_posts/2021-12-08-introducing-opensearch-benchmark.md
@@ -7,6 +7,7 @@ authors:
 date: 2021-12-08 01:01:01 -0700
 categories:
   - update
+redirect_from: "/blog/update/2021/12/introducing-opensearch-benchmark/"
 ---
 
 We would like to introduce OpenSearch Benchmark - a community driven, open source fork of [Rally](https://esrally.readthedocs.io/en/stable/). The mission of the project is to provide a convenient and reliable performance testing framework for OpenSearch. OpenSearch Benchmark intends to be compatible with OpenSearch and Amazon OpenSearch Service. OpenSearch Benchmark is currently in alpha release and will be maintained under the Apache License, Version 2.0 (ALv2). 

--- a/_posts/2021-12-09-connecting-java-high-level-rest-client-with-opensearch-over-https.markdown
+++ b/_posts/2021-12-09-connecting-java-high-level-rest-client-with-opensearch-over-https.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "This post walks through the steps to configure Java High-level REST client to connect to OpenSearch over HTTPS."
+redirect_from: "/blog/technical-post/2021/12/connecting-java-high-level-rest-client-with-opensearch-over-https/"
 ---
 
 If you have ever used OpenSearch with a Java application, you might have come across the [OpenSearch Java high-level REST client](https://opensearch.org/docs/latest/clients/java-rest-high-level/). The REST client provides OpenSearch APIs as methods, and makes it easier for a Java application to interact with OpenSearch using request/response objects.

--- a/_posts/2021-12-11-update-to-1-2-1.markdown
+++ b/_posts/2021-12-11-update-to-1-2-1.markdown
@@ -8,7 +8,7 @@ categories:
   - releases
 
 excerpt: "Update Dec 14, 2021: The new CVE-2021-45046 affecting Log4j 2.15.0 was published earlier today, and OpenSearch 1.2.1 includes that version of Log4j. As with the previous issue, the team has not been able to reproduce this issue, nor any patterns thought to trigger this issue. Out of an abundance of caution, and, as indicated in the advisory, we will release a new version of OpenSearch shortly that uses Log4j 2.16.0 which is not affected by this new CVE."
-
+redirect_from: "/blog/releases/2021/12/update-to-1-2-1/"
 ---
 
 ### Update 2021-12-22

--- a/_posts/2021-12-15-Introducing-Data-Prepper-1.2.0-with-Log-Pipelines.md
+++ b/_posts/2021-12-15-Introducing-Data-Prepper-1.2.0-with-Log-Pipelines.md
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: " You can start using Data Prepper 1.2.0 for log ingestion today. This release enables log collection into OpenSearch from Fluent Bit."
+redirect_from: "/blog/technical-post/2021/12/Introducing-Data-Prepper-1.2.0-with-Log-Pipelines/"
 ---
 
 Development teams are using Data Prepper and OpenSearch to better understand their applications through 

--- a/_posts/2021-12-16-update-1-2-2.markdown
+++ b/_posts/2021-12-16-update-1-2-2.markdown
@@ -8,7 +8,7 @@ categories:
   - releases
 
 excerpt: "As indicated in the previous blog post, CVE-2021-45046 was issued shortly following the release of OpenSearch 1.2.1. This new CVE advises upgrading from Log4j 2.15.0 (used in OpenSearch 1.2.1) to Log4j 2.16.0. Out of an abundance of caution, the team is releasing OpenSearch 1.2.2 which includes Log4j 2.16.0. While there has been no observed reproduction of the issue described in CVE-2021-45046, Log4j 2.16.0 takes much more extensive JNDI mitigation measures."
-
+redirect_from: "/blog/releases/2021/12/update-1-2-2/"
 ---
 
 ### Update 2021-12-22

--- a/_posts/2021-12-21-oracle-announcement.markdown
+++ b/_posts/2021-12-21-oracle-announcement.markdown
@@ -8,6 +8,7 @@ categories:
   - partners
 twittercard:
   description: "Oracle Cloud Infrastructure’s (OCI) announcement of a fully managed search service based on OpenSearch"
+redirect_from: "/blog/partners/2021/12/oracle-announcement/"
 ---
 
 ## Oracle Cloud Infrastructure - Welcome to the OpenSearch community!

--- a/_posts/2021-12-22-update-1-2-3.markdown
+++ b/_posts/2021-12-22-update-1-2-3.markdown
@@ -8,7 +8,7 @@ categories:
   - releases
 
 excerpt: "CVE-2021-45105 for Log4j was issued after the release of OpenSearch 1.2.2. This CVE advises upgrading to Log4j 2.17.0. While there has been no observed reproduction of the issue described in CVE-2021-45105 in OpenSearch, we have released OpenSearch 1.2.3 which updates Log4j to version 2.17.0."
-
+redirect_from: "/blog/releases/2021/12/update-1-2-3/"
 ---
 
 ### Update your clusters to 1.2.3

--- a/_posts/2022-01-20-opensearch-as-a-service.markdown
+++ b/_posts/2022-01-20-opensearch-as-a-service.markdown
@@ -8,6 +8,7 @@ categories:
   - partners
 twittercard:
   description: "OpenSearch is now available as a certified container with auto-clustering inside Virtuozzo DevOps PaaS. Start offering OpenSearch Cluster as a service"
+redirect_from: "/blog/partners/2022/01/opensearch-as-a-service/"
 ---
 
 ## How to Offer OpenSearch as a Service using Virtuozzo DevOps PaaS  

--- a/_posts/2022-01-21-dashboards-plugins-intro.markdown
+++ b/_posts/2022-01-21-dashboards-plugins-intro.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "Plugins are fundamental to how OpenSearch works, and that similarity extends to OpenSearch Dashboards too..."
+redirect_from: "/blog/technical-post/2022/01/dashboards-plugins-intro/"
 ---
 
 Plugins are fundamental to how OpenSearch works, and the similarity extends to OpenSearch Dashboards too. Infact almost everything that you see inside OpenSearch Dashboards is built inside a plugin. As a follow up to the blog post on how plugins work for OpenSearch, this post will explore how plugins work for OpenSearch Dashboards.

--- a/_posts/2022-01-24-calyptia-partner-blog-announcement.md
+++ b/_posts/2022-01-24-calyptia-partner-blog-announcement.md
@@ -9,7 +9,7 @@ categories:
   - releases
 
 excerpt: "Calyptia and the OpenSearch project team are partnering to build OpenSearch connectors for Fluent Bit and Fluentd."
-
+redirect_from: "/blog/releases/2022/01/calyptia-partner-blog-announcement/"
 ---
 
 We are excited to share that [Calytpia](https://calyptia.com/) and the OpenSearch project team [are partnering](https://calyptia.com/2022/01/20/calyptia-and-opensearch-partner-to-build-first-party-connectors-to-fluent-bit-and-fluentd/) to build OpenSearch connectors for [Fluent Bit](https://fluentbit.io/) and [Fluentd](https://www.fluentd.org/). These open source [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) graduated projects are commonly used for log collection, processing, and forwarding.

--- a/_posts/2022-02-01-data-prepper-1.2.1-performance-testing.md
+++ b/_posts/2022-02-01-data-prepper-1.2.1-performance-testing.md
@@ -8,7 +8,7 @@ categories:
   - technical-post
 
 excerpt: "Following the launch of log pipeline in Data Prepper 1.2, the Data Prepper Team is excited to share the results of the Data Prepper performance testing suite. The goal is to create a tool that can simulate a set of real-world scenarios in any environment while maintaining compatibility with popular log ingestion applications."
-
+redirect_from: "/blog/technical-post/2022/02/data-prepper-1.2.1-performance-testing/"
 ---
 
 Following the launch of log pipeline in [Data Prepper 1.2](https://www.opensearch.org/blog/technical-post/2021/12/Introducing-Data-Prepper-1.2.0-with-Log-Pipelines/), the Data Prepper Team are excited to share the results of the Data Prepper performance testing suite. The goal is to create a tool that can simulate a set of real-world scenarios in any environment while maintaining compatibility with popular log ingestion applications. In all performance test results discussed below, the test environments and configurations are identical, except where the same option is not available for all applications. See testing limitations section for additional details.

--- a/_posts/2022-02-02-feature-deep-dive-opensearch-sql-basic-queries.markdown
+++ b/_posts/2022-02-02-feature-deep-dive-opensearch-sql-basic-queries.markdown
@@ -7,7 +7,7 @@ authors:
 date: 2022-02-02
 categories: 
   - feature
-
+redirect_from: "/blog/feature/2022/02/feature-deep-dive-opensearch-sql-basic-queries/"
 ---
 
 In this post, we’ll explore some of the features and capabilities supported by OpenSearch SQL. We also briefly introduce how SQL engine works internally.

--- a/_posts/2022-02-07-partner-hidora.md
+++ b/_posts/2022-02-07-partner-hidora.md
@@ -9,7 +9,7 @@ categories:
 twittercard:
   description: "Hidora is an expert in providing custom solutions for all sizes of businesses. Hidora Cloud Hosting Solutions are just what you need if you want an efficient, secure and scalable cloud hosting solution that is tailored to your needs. We offer different plans that are scalable according to your specific requirements so you can find one that suits you best. Our PaaS help developers to host their applications in few minutes with DevOps philosophy."
 excerpt: "Hidora is an expert in providing custom solutions for all sizes of businesses. Hidora Cloud Hosting Solutions are just what you need if you want an efficient, secure and scalable cloud hosting solution that is tailored to your needs. We offer different plans that are scalable according to your specific requirements so you can find one that suits you best. Our PaaS help developers to host their applications in few minutes with DevOps philosophy"
-
+redirect_from: "/blog/partners/2022/02/partner-hidora/"
 ---
 
 Who we are

--- a/_posts/2022-02-10-getting-started-with-fluentd-and-opensearch.md
+++ b/_posts/2022-02-10-getting-started-with-fluentd-and-opensearch.md
@@ -9,6 +9,7 @@ categories:
  - technical
 
 excerpt: "The OpenSearch project is, a community-driven open-source search and analytics suite derived from Apache 2.0 licensed Elasticsearch 7.10.2 and Kibana 7.10.2. In order to get started with OpenSearch you will need to get data into OpenSearch. A new method, built through a partnership of Calyptia and the OpenSearch project, is native plugins for Fluentd. Fluentd is an open-source log and metrics processor that is part of the Cloud Native Computing Foundation (CNCF)."
+redirect_from: "/blog/technical/2022/02/getting-started-with-fluentd-and-opensearch/"
 ---
 
 The OpenSearch project is, a community-driven open-source search and analytics suite derived from Apache 2.0 licensed Elasticsearch 7.10.2 and Kibana 7.10.2. In order to get started with OpenSearch you will need to get data into OpenSearch. A new method, built through a partnership of Calyptia and the OpenSearch project, is native plugins for Fluentd. Fluentd is an open-source log and metrics processor that is part of the Cloud Native Computing Foundation (CNCF).

--- a/_posts/2022-02-15-a-quick-opensearch-primer.md
+++ b/_posts/2022-02-15-a-quick-opensearch-primer.md
@@ -9,6 +9,7 @@ categories:
  - intro
 
 excerpt: "OpenSearch is an open-source project built on top of Apache Lucene, a powerful indexing and search library.  Even if you’ve never heard of an indexing library before, you’re still probably more familiar with indexing than you think. "
+redirect_from: "/blog/intro/2022/02/a-quick-opensearch-primer/"
 ---
 
 ### First time here?

--- a/_posts/2022-02-17-shard-indexing-backpressure-in-opensearch.markdown
+++ b/_posts/2022-02-17-shard-indexing-backpressure-in-opensearch.markdown
@@ -9,6 +9,7 @@ authors:
 date:   2022-02-17
 categories:
   - feature
+redirect_from: "/blog/feature/2022/02/shard-indexing-backpressure-in-opensearch/"
 ---
 
 In this post we wish to dive into the Shard Indexing Backpressure feature which got launched with OpenSearch 1.2.0 and how it can improve cluster reliability. The Indexing APIs in OpenSearch such as ``_bulk`` allows you to write data in the cluster, which is distributed across multiple shards, on multiple data nodes. However, at times indexing requests may suffer performance degradation due to a number of reasons including non-optimal cluster configuration, shard strategy, traffic spikes, available node resources and more. These issues are further exacerbated for larger multi-node cluster and indices with many shards. All of these could cause out-of-memory errors, long garbage collection (GC) pauses, and reduced throughput, affecting the overall availability of data nodes in addition to degrading performance. This in turn would impact the node's ability to perform useful work. In addition, these node drop events could cascade due to a lack of effective backpressure which puts the entire cluster at risk.

--- a/_posts/2022-02-25-roadmap-proposal.md
+++ b/_posts/2022-02-25-roadmap-proposal.md
@@ -9,7 +9,7 @@ categories:
 twittercard:
   description: "As part of thinking about releases for this year, I’ve been trying to sketch out a schedule of major and minor release dates through 2023. I wanted to share with you what I have so far, and hear your thoughts."
 excerpt: "As part of thinking about releases for this year, I’ve been trying to sketch out a schedule of major and minor release dates through 2023. I wanted to share with you what I have so far, and hear your thoughts."
-
+redirect_from: "/blog/partners/2022/02/roadmap-proposal/"
 ---
 
 As part of thinking about releases for this year, I’ve been trying to sketch out a schedule of major and minor release dates through 2023. I wanted to share with you what I have so far.

--- a/_posts/2022-03-01-auto-backport-in-opensearch.markdown
+++ b/_posts/2022-03-01-auto-backport-in-opensearch.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "This post provides details on how we navigated backports in OpenSearch and pursued automation."
+redirect_from: "/blog/technical-post/2022/03/auto-backport-in-opensearch/"
 ---
 
 Backporting is a common process in OpenSearch in order to maintain release branches separate from main and to be ready for a release. This blog post talks about how the team navigated backports manually in OpenSearch and pursued automation to streamline the process and use it across various repos.

--- a/_posts/2022-03-09-fine-dining-for-indices.md
+++ b/_posts/2022-03-09-fine-dining-for-indices.md
@@ -11,7 +11,7 @@ categories:
 excerpt: "There are a lot of reasons you might want to fine-tune indices on an OpenSearch cluster. Every workflow has different requirements, and the default behavior of OpenSearch might not suit your use case. Before ingesting with reckless abandon to fill an index with data, enjoy some insight on tuning an index. "
 meta_description: "This article helps create the most efficient OpenSearch index mapping that you can think of."
 meta_keywords: "data ingestion, indices, opensearch, index mapping"
-
+redirect_from: "/blog/intro/2022/03/fine-dining-for-indices/"
 ---
 
 ## Is Your Cluster Eating Healthy? 

--- a/_posts/2022-03-17-launch-announcement-1-3-0.markdown
+++ b/_posts/2022-03-17-launch-announcement-1-3-0.markdown
@@ -11,6 +11,7 @@ categories:
   - releases
 twittercard:
     description: "With this latest version of the OpenSearch distribution (OpenSearch, OpenSearch Dashboards, as well as plugins and tools) you can enjoy a number of new features and enhancements as well as improvements to stability and efficiency."
+redirect_from: "/blog/releases/2022/03/launch-announcement-1-3-0/"
 ---
 
 With this latest version of the OpenSearch distribution (OpenSearch, OpenSearch Dashboards, as well as plugins and tools) you can enjoy a number of new features and enhancements as well as improvements to stability and efficiency.

--- a/_posts/2022-03-22-Introducing-Data-Prepper-1.3.0-with-New-Aggregation-Processor.md
+++ b/_posts/2022-03-22-Introducing-Data-Prepper-1.3.0-with-New-Aggregation-Processor.md
@@ -10,6 +10,7 @@ categories:
   - technical-post
 twittercard:
   description: " Data Prepper 1.3.0 is available for use today. This release provides a log aggregation processor and other new processors."
+redirect_from: "/blog/technical-post/2022/03/Introducing-Data-Prepper-1.3.0-with-New-Aggregation-Processor/"
 ---
 
 Data Prepper is an open source data collector for trace and log data that can filter, 

--- a/_posts/2022-03-24-getting-started-with-fluent-bit-and-opensearch.md
+++ b/_posts/2022-03-24-getting-started-with-fluent-bit-and-opensearch.md
@@ -8,6 +8,7 @@ categories:
 - technical
 twittercard:
     description: "We recently announced the release of Fluent Bit 1.9, and while there are a number of new features and enhancements to its already impressive speed, scale, and efficiency, one feature we are really excited about is the OpenSearch plugin for Fluent Bit. Fluent Bit is an Apache 2.0 open source lightweight log and metric processor that can gather data from many sources, while the OpenSearch project is a community-driven open-source search and analytics suite derived from Elasticsearch 7.10.2 and Kibana 7.10.2."
+redirect_from: "/blog/technical/2022/03/getting-started-with-fluent-bit-and-opensearch/"
 ---
 
 We recently announced the release of Fluent Bit 1.9, and while there are a number of new features and enhancements to its already impressive speed, scale, and efficiency, one feature we are really excited about is the OpenSearch plugin for Fluent Bit. Fluent Bit is an Apache 2.0 open source lightweight log and metric processor that can gather data from many sources, while the OpenSearch project is a community-driven open-source search and analytics suite derived from Elasticsearch 7.10.2 and Kibana 7.10.2.

--- a/_posts/2022-03-28-opensearch-java-runtime.markdown
+++ b/_posts/2022-03-28-opensearch-java-runtime.markdown
@@ -12,6 +12,7 @@ categories:
 twittercard:
   description: "OpenSearch ships with a bundled Java Development Kit (JDK) that has recently been updated to version 11 (LTS). In this blog post we'll explain this change, and describe new features that make swapping the Java runtime easier."
 excerpt: "OpenSearch ships with a bundled Java Development Kit (JDK) that has recently been updated to version 11 (LTS)."
+redirect_from: "/blog/technical-post/2022/03/opensearch-java-runtime/"
 
 ---
 At the time of the fork OpenSearch inherited bundling OpenJDK 15, and eight releases have used AdoptOpenJDK 15.0.1+9 as the default runtime, replaced with Adoptium (Temurin) 11.0.14.1+1 in OpenSearch 1.3.0. This change was primarily driven by the fact that JDK 11 is a Long-Term Support (LTS) release, and JDK 15 is not. LTS releases of JDKs focus on stability, therefore you can expect future versions of OpenSearch to always default to bundling a LTS JDK.

--- a/_posts/2022-04-07-launching-open-source-operator-for-openSearch.markdown
+++ b/_posts/2022-04-07-launching-open-source-operator-for-openSearch.markdown
@@ -10,6 +10,8 @@ twittercard:
   description: "The Kubernetes OpenSearch Operator is used for automating the deployment, provisioning, management, and orchestration of OpenSearch clusters and OpenSearch dashboards."
 
 excerpt: "The Operator enables high-level API use, for easily running advanced OpenSearch operations on Kubernetes."
+redirect_from: "/blog/technical-post/2022/04/launching-open-source-operator-for-openSearch/"
+
 ---
 
 

--- a/_posts/2022-04-15-Partner-Highlight-Pureinsights-adds-OpenSearch-to-its-Discovery-Platform.markdown
+++ b/_posts/2022-04-15-Partner-Highlight-Pureinsights-adds-OpenSearch-to-its-Discovery-Platform.markdown
@@ -8,6 +8,7 @@ categories:
   - partners
 twittercard:
     description: "Open source search engine experts Pureinsights add OpenSearch to their Discovery Platform."
+redirect_from: "/blog/partners/2022/04/Partner-Highlight-Pureinsights-adds-OpenSearch-to-its-Discovery-Platform/"
 ---
 
 [Pureinsights](https://pureinsights.com/) has deep expertise in the design, implementation and management of open source search projects. Our team has undertaken hundreds of projects using Solr and Elasticsearch and we have developed technology assets that enhance these search engines most notably around adding fine grain document understanding pipelines and machine learning model based document vectorizers. On the query side we enable Google BERT based FAQs and Featured Snippets (Extractive Answers) as well as Knowledge Graph Answers (via NEO4J) to OpenSearch applications. We now embrace and add OpenSearch to our stable.

--- a/_posts/2022-04-26-partner-highlight-titaniam-byok.md
+++ b/_posts/2022-04-26-partner-highlight-titaniam-byok.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-04-26 01:01:01 -0700
 categories:
   - partners
+redirect_from: "/blog/partners/2022/04/partner-highlight-titaniam-byok/"
 ---
 
 We recently learnt that a number of our prospects were running their B2B SaaS platform on top of Elasticsearch. Nearly all of them asked if we also support AWS OpenSearch. Many of them are running older versions of Elasticsearch and are evaluating if they should upgrade to a more recent version or migrate to OpenSearch to stick to Apache license. This is about to play out in large scale in the upcoming months. SaaS companies operate on their customers' data, and they have to take all the precautions within their reach to protect that data. 

--- a/_posts/2022-05-03-release-candidate-2-0-available.md
+++ b/_posts/2022-05-03-release-candidate-2-0-available.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-05-03 10:01:01 -0700
 categories:
   - releases
+redirect_from: "/blog/releases/2022/05/release-candidate-2-0-available/"
 ---
 
 I am excited to share that the release candidate (RC1) for version 2.0.0 of OpenSearch and OpenSearch Dashboards is now available for testing and validation. As a release candidate, this version of the project is feature complete and has passed automated testing, but we'll continue to add bug fixes until the full "General Availability" (GA) release date.

--- a/_posts/2022-05-09-opensearchcon.markdown
+++ b/_posts/2022-05-09-opensearchcon.markdown
@@ -13,7 +13,7 @@ categories:
 twittercard:
   description: "Join the OpenSearch community on September 21st in Seattle for #OpenSearchCon! Connect with peers and partners who can help you solve today’s search challenges and unlock the next phase of your OpenSearch journey."
 excerpt: "Join the OpenSearch community on September 21st in Seattle for #OpenSearchCon!"
-
+redirect_from: "/blog/community/2022/05/opensearchcon/"
 ---
 
 ![OpenSearchCon](/assets/media/blog-images/2022-05-09-opensearchcon/opensearchcon.jpg){: .img-fluid}

--- a/_posts/2022-05-10-oracle-cloud-infrastructure-search-service.markdown
+++ b/_posts/2022-05-10-oracle-cloud-infrastructure-search-service.markdown
@@ -10,7 +10,7 @@ categories:
   - partners
 
 excerpt: "Oracle has released it's Cloud Infrastructure Search Service with OpenSearch!"
-
+redirect_from: "/blog/partners/2022/05/oracle-cloud-infrastructure-search-service/"
 ---
 
 Late last year, we [shared](https://opensearch.org/blog/partners/2021/12/oracle-announcement/) the news that Oracle joined the OpenSearch community and launched the public beta of their new service, OCI Search Service with OpenSearch. Today we’d like to congratulate them on the global availability of their service in all thirty OCI regions. The offering is a fully managed search service based on OpenSearch. The service automates common operational activities like patching, updating, upgrading, resizing, and backups. Using the reference architectures, customers will have access to a validated architecture to deploy and configure the service for log aggregation and in-application search.

--- a/_posts/2022-05-11-fluentcon-announcement.md
+++ b/_posts/2022-05-11-fluentcon-announcement.md
@@ -8,6 +8,7 @@ categories:
  - community
 
 excerpt: "The Fluent community is excited to partner with the OpenSearch community in hosting another installment of FluentCon. The conference is a co-located event alongside [KubeCon Europe](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) on May 16th in Valencia, Spain, as well as virtually from your laptop. Similar to previous FluentCons, this event will feature both general sessions as well as in-depth workshops focused on core use cases, strategies for managing observability at scale, and conversation on how we build forward."
+redirect_from: "/blog/community/2022/05/fluentcon-announcement/"
 ---
 
 ![FluentCon EU 2022](/assets/media/blog-images/2022-05-11-fluentcon/fluentconeu2022.svg){: .img-fluid}

--- a/_posts/2022-05-13-tag-youre-it.md
+++ b/_posts/2022-05-13-tag-youre-it.md
@@ -7,6 +7,7 @@ authors:
 date: 2022-05-13
 categories:
  - intro
+redirect_from: "/blog/intro/2022/05/tag-youre-it/"
 ---
 
 ## Tag, You’re It! 

--- a/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
+++ b/_posts/2022-05-16-opentelemetry-metrics-for-data-prepper.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-05-17 06:00:00 +0200
 categories:
   - technical-post
+redirect_from: "/blog/technical-post/2022/05/opentelemetry-metrics-for-data-prepper/"
 ---
 Data Prepper offers great capabilities for ingesting traces and logs into OpenSearch.
 Until now, that leaves out the third pillar of observability: metrics.

--- a/_posts/2022-05-19-introducing-logstash-input-opensearch-plugin-for-opensearch.md
+++ b/_posts/2022-05-19-introducing-logstash-input-opensearch-plugin-for-opensearch.md
@@ -8,6 +8,7 @@ categories:
  - community
 
 excerpt: "In this post, we will talk about the new input plugin for Logstash. We will show how it works with OpenSearch by giving an example on how to read data from OpenSearch, perform a transformation, and index back to OpenSearch. This use case is useful in the event you want to migrate from one OpenSearch major version to another (e.g. 1.3 → 2.0)."
+redirect_from: "/blog/community/2022/05/introducing-logstash-input-opensearch-plugin-for-opensearch/"
 ---
 
 ## Overview

--- a/_posts/2022-05-26-opensearch-2-0-is-now-available.md
+++ b/_posts/2022-05-26-opensearch-2-0-is-now-available.md
@@ -10,6 +10,7 @@ authors:
 date:   2022-05-26 09:45:00 -0700
 categories:
   - releases
+redirect_from: "/blog/releases/2022/05/opensearch-2-0-is-now-available/"
 ---
  
 OpenSearch 2.0 is now generally available! This release incorporates user feedback and contributions from across the OpenSearch community to deliver a wealth of new capabilities and performance enhancements. We’re grateful for the collaborative effort of the community to build a distributed search and analytics toolset with the features, usability, and open-source flexibility that developers can rely on to create their most innovative solutions yet.

--- a/_posts/2022-06-06-wtit.markdown
+++ b/_posts/2022-06-06-wtit.markdown
@@ -9,7 +9,7 @@ categories:
   - partners
 
 excerpt: "WorldTech IT is excited to join the OpenSearch community as users, contributors, and official OpenSearch partners"
-
+redirect_from: "/blog/partners/2022/06/wtit/"
 ---
 
 [WorldTech IT](https://wtit.com/) is excited to join the OpenSearch community as users, contributors, and **official OpenSearch partners**. As the leader in [Professional](https://wtit.com/f5-services/f5-professional-services-load-balancer-support/) and [Managed Services](https://wtit.com/f5-services/f5-managed-services/) integrating [AWS](https://wtit.com/migrate-f5-big-ip-to-aws/) with [F5](https://wtit.com/f5-products/) and [NGINX](https://wtit.com/nginx-professional-services/) solutions, we rely on OpenSearch for use within our [Cloud.Red](https://wtit.com/cloud-red/) platform. Before we get into how we use and promote OpenSearch, you may be wondering where F5 and NGINX come into the picture.

--- a/_posts/2022-06-07-opensearch-2-0-clients-released.md
+++ b/_posts/2022-06-07-opensearch-2-0-clients-released.md
@@ -13,6 +13,7 @@ authors:
 date: 2022-06-07
 categories:
  - releases
+redirect_from: "/blog/releases/2022/06/opensearch-2-0-clients-released/"
 ---
 
 On the heels of the OpenSearch 2.0 release, the OpenSearch team is excited to announce that all OpenSearch clients have been released to support version 2.0. Not only were all clients updated, but Vacha Shah went above and beyond to improve each client repo by improving test coverage for multiple versions, support to test against unreleased versions, and adding backport functionality. Vacha made it so easy that the co-maintainer of the PHP repo provided the following quote:

--- a/_posts/2022-06-23-S3-Log-Ingestion-Using-Data-Prepper-1.5.0.md
+++ b/_posts/2022-06-23-S3-Log-Ingestion-Using-Data-Prepper-1.5.0.md
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "You can start using Data Prepper 1.5.0 to ingest log data from S3 today."
+redirect_from: "/blog/technical-post/2022/06/S3-Log-Ingestion-Using-Data-Prepper-1.5.0/"
 ---
 
 Data Prepper is an open-source data collector for data ingestion into OpenSearch. It currently supports trace analytics 

--- a/_posts/2022-06-29-announcing-style-guide.md
+++ b/_posts/2022-06-29-announcing-style-guide.md
@@ -6,6 +6,7 @@ authors:
 date: 2022-06-29
 categories: 
   - community
+redirect_from: "/blog/community/2022/06/announcing-style-guide/"
 ---
 
 The OpenSearch team is excited to announce the release of the [style guidelines](https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md) for our documentation and marketing content! These guidelines cover the style standards and terms to be observed when creating OpenSearch content. Our growing team of technical writers and editors is committed to providing complete and best-in-class documentation to the OpenSearch community, and releasing our style guidelines reflects this commitment.

--- a/_posts/2022-07-07-opensearch-2-1-is-available-now.md
+++ b/_posts/2022-07-07-opensearch-2-1-is-available-now.md
@@ -7,6 +7,7 @@ authors:
 date:   2022-07-07 11:59:00 -0700
 categories:
   - releases
+redirect_from: "/blog/releases/2022/07/opensearch-2-1-is-available-now/"
 ---
 
 OpenSearch 2.1 is now [available for download](https://opensearch.org/downloads.html)! This release includes new features and significant enhancements aimed at boosting performance and expanding functionality for search, analytics, and observability use cases. OpenSearch 2.1 delivers a number of capabilities that have come up consistently in the OpenSearch community, including a dedicated node type for running machine learning (ML) workloads at scale, enhanced data protection capabilities, more flexible search options, and user interface upgrades.

--- a/_posts/2022-07-12-year-one-the-opensearch-project.md
+++ b/_posts/2022-07-12-year-one-the-opensearch-project.md
@@ -6,6 +6,7 @@ authors:
 date: 2022-07-12
 categories:
  - community
+redirect_from: "/blog/community/2022/07/year-one-the-opensearch-project/"
 ---
 
 

--- a/_posts/2022-07-13-whatsnew-document-level-monitors.md
+++ b/_posts/2022-07-13-whatsnew-document-level-monitors.md
@@ -7,7 +7,7 @@ authors:
 date: 2022-07-13
 categories:
  - technical-post
- 
+redirect_from: "/blog/technical-post/2022/07/whatsnew-document-level-monitors/" 
 ---
 
 In OpenSearch 2.0, OpenSearch released document-level monitors. With document-level monitors, alert creators can monitor documents as they are indexed in OpenSearch. If an alert is configured on a document-level monitor, the alert returns a reference to the document that triggered the alert. In this blog post, we will provide the following:

--- a/_posts/2022-07-20-bottlerocket-k8s-fluent-bit.markdown
+++ b/_posts/2022-07-20-bottlerocket-k8s-fluent-bit.markdown
@@ -7,6 +7,7 @@ date:   2022-07-20
 categories:
   - technical-post
 excerpt: "Today, I’m going to show you how to run OpenSearch with the OpenSearch Operator on Kubernetes using the Bottlerocket and then add Fluent Bit to collect logs from the nodes of the same Kubernetes cluster."
+redirect_from: "/blog/technical-post/2022/07/bottlerocket-k8s-fluent-bit/"
 ---
 
 It's great to be writing about OpenSearch again!

--- a/_posts/2022-07-20-content-compass.md
+++ b/_posts/2022-07-20-content-compass.md
@@ -7,7 +7,7 @@ authors:
 date: 2022-07-22
 categories:
  - intro
-
+redirect_from: "/blog/intro/2022/07/content-compass/"
 meta_keywords: "data ingestion, ingestion, open source, opensearch, community, observability"
 meta_description: "Using OpenSearch to ingest community tag data helps us target learning material towards where knowledge gaps actually exist."
 ---

--- a/_posts/2022-07-21-aggregate-by-multiple-terms.md
+++ b/_posts/2022-07-21-aggregate-by-multiple-terms.md
@@ -7,7 +7,7 @@ authors:
 date: 2022-07-21
 categories:
  - technical-post
-
+redirect_from: "/blog/technical-post/2022/07/aggregate-by-multiple-terms/"
 excerpt: "Multi-terms aggregation allows you to group and sort results from a query. While terms aggregation has existed in OpenSearch for some time, multi-terms aggregation allows for sorting by deeper levels. This is particularly useful in the observability space."
 ---
 

--- a/_posts/2022-07-24-opensearch-plugin-zips-now-in-maven-repo.markdown
+++ b/_posts/2022-07-24-opensearch-plugin-zips-now-in-maven-repo.markdown
@@ -8,6 +8,7 @@ categories:
   - technical-post
 twittercard:
   description: "Details on how to consume OpenSearch plugin zips from a Maven repo and the process involved in shipping them to a Maven repo."
+redirect_from: "/blog/technical-post/2022/08/opensearch-plugin-zips-now-in-maven-repo/"
 ---
 
 Starting with the release of OpenSearch `2.1.0`, OpenSearch plugin zips are now signed and published to a central Apache Maven [repo](https://repo1.maven.org/maven2/org/opensearch/plugin/).  Using the [Release zips](https://repo1.maven.org/maven2/org/opensearch/plugin/) and [Snapshot zips](https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/) Maven Repo URLs, OpenSearch plugin zips can now be consumed  as a dependency to build other plugins or fetched as standalone components for your OpenSearch cluster. 

--- a/_posts/2022-08-11-opensearch-2-2-is-now-available.md
+++ b/_posts/2022-08-11-opensearch-2-2-is-now-available.md
@@ -8,6 +8,7 @@ authors:
 date:   2022-08-11 13:48:00 -0700
 categories:
   - releases
+redirect_from: "/blog/releases/2022/08/opensearch-2-2-is-now-available/"
 ---
 
 OpenSearch 2.2 is ready to [download](https://opensearch.org/downloads.html)! This release includes 23 new features and 12 enhancements to help you build and optimize your solutions for search, analytics, and observability workloads. Following are some highlights of the capabilities you can use to advance machine learning (ML) models, data visualizations, cluster resiliency, and more. As always, the [release notes](https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.2.0.md) provide further details.

--- a/_posts/2022-08-17-dattell-compares.markdown
+++ b/_posts/2022-08-17-dattell-compares.markdown
@@ -6,7 +6,7 @@ authors:
 date: 2022-08-17
 categories:
   - partners
-
+redirect_from: "/blog/partners/2022/08/dattell-compares/"
 ---
 
 OpenSearch partner and contributor [Dattell](https://dattell.com/) has published a [blog post](https://dattell.com/data-architecture-blog/opensearch-vs-elasticsearch/) that explores technical and business aspects of the OpenSearch project and Elasticsearch offerings. The post by Dattell co-founder Maria Hatfield, whose company offers consulting support and managed services for OpenSearch, Elasticsearch, and Kafka, offers an in-depth look at how these software tools stack up in areas like community, licensing, and security, as well as comparing feature sets, visualization tools, and documentation. Check out Dattell’s [post](https://dattell.com/data-architecture-blog/opensearch-vs-elasticsearch/) to see their perspective.

--- a/_posts/2022-08-23-Agent-Ingestion-Usage-In-OpenSearch-Survey-Results.md
+++ b/_posts/2022-08-23-Agent-Ingestion-Usage-In-OpenSearch-Survey-Results.md
@@ -6,6 +6,7 @@ authors:
 date: 2022-08-23
 categories:
  - technical-post
+redirect_from: "/blog/technical-post/2022/08/Agent-Ingestion-Usage-In-OpenSearch-Survey-Results/"
 ---
 
 First, a huge thank you to all of you who responded to the survey. Understanding how you use agents in your ingestion pipelines helps us prioritize use cases that deliver the most value to the community.

--- a/_posts/2022-08-23-New-series-From-the-editors-desk.md
+++ b/_posts/2022-08-23-New-series-From-the-editors-desk.md
@@ -6,6 +6,7 @@ authors:
 date: 2022-08-31
 categories: 
   - community
+redirect_from: "/blog/community/2022/08/New-series-From-the-editors-desk/"
 ---
 
 As part of our commitment to providing complete and best-in-class documentation to the OpenSearch community, we want to ensure that you have visibility into how we approach creating bar-raising content. To that end, we will be publishing regular blog posts with tips, guidance, and best practices that will help contributors collaborate with us. Subjects may include technical writing, style, voice and tone, brand messaging, and other topics relevant to the production of our documentation. We hope you find this to be useful, and we would love to hear your thoughts on any of the subjects we discuss in this series. Please feel free to make your voice heard as part of the OpenSearch community through our [community meetings](https://www.meetup.com/OpenSearch/), [forum discussions](https://forum.opensearch.org/), and [GitHub repository](https://github.com/opensearch-project).

--- a/_posts/2022-08-25-day-in-the-life-of-a-release-manager.md
+++ b/_posts/2022-08-25-day-in-the-life-of-a-release-manager.md
@@ -6,6 +6,7 @@ authors:
 date: 2022-08-25
 categories:
  - community
+redirect_from: "/blog/community/2022/08/day-in-the-life-of-a-release-manager/"
 ---
 
 An OpenSearch version release can be a daunting prospect, especially if you’re the one managing it. There are ambiguously worded tasks that need to be completed, deadlines to be met. Now not only do you have to get your work done, but you also have to make sure that everyone else does too. Facing this challenge for the first time, I thought it would be useful to document the process so that any future release managers can avoid the mistakes I made.

--- a/_posts/2022-09-09-snapshot-operations.md
+++ b/_posts/2022-09-09-snapshot-operations.md
@@ -8,6 +8,7 @@ authors:
 date:   2022-09-09 00:00:00 -0700
 categories:
   - technical-post
+redirect_from: "/blog/technical-post/2022/09/snapshot-operations/"
 ---
 
 In this post, we want to dive deep into snapshot operations in OpenSearch. Snapshots are backups of a cluster’s indexes and state. The state can include cluster settings, node information, index metadata, and shard allocation information. Snapshots are used to recover from failures, such as a red cluster, or to move data from one cluster to another without data loss. Remote searchable snapshots will enable users to restore a snapshot without downloading all the shards on the cluster nodes, requiring us to dive deep into the existing snapshot operations within OpenSearch.

--- a/_posts/2022-09-12-sql-search-relevance-selective-aggregation-and-window-functions-in-OpenSearch.md
+++ b/_posts/2022-09-12-sql-search-relevance-selective-aggregation-and-window-functions-in-OpenSearch.md
@@ -7,6 +7,7 @@ authors:
 date: 2022-09-12
 categories:
  - technical-post
+redirect_from: "/blog/technical-post/2022/09/sql-search-relevance-selective-aggregation-and-window-functions-in-OpenSearch/"
 ---
 
 According to a [review by IEEE Spectrum in 2022](https://spectrum.ieee.org/top-programming-languages-2022), SQL is the sixth most popular programming language. IEEE came to this conclusion by pulling and weighting data across GitHub, Google, Stack Overflow, Twitter, and IEEE Xplore. Did you know that OpenSearch offers a way to [query OpenSearch using SQL](https://opensearch.org/blog/feature/2022/02/feature-deep-dive-opensearch-sql-basic-queries/)? In recent releases, the SQL plugin included support for search relevance, selective aggregation, and window functions. You can use the REST API or use the OpenSearch Query Workbench to query OpenSearch using the SQL plugin. Today, we will use the Query Workbench inside the OpenSearch Playground environment to walk through search relevance, selective aggregation, and window functions.

--- a/_posts/2022-09-14-opensearch-2-3-is-ready-for-download.md
+++ b/_posts/2022-09-14-opensearch-2-3-is-ready-for-download.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-09-14 12:15:00 -0700
 categories:
   - releases
+redirect_from: "/blog/releases/2022/09/opensearch-2-3-is-ready-for-download/"
 ---
 
 [OpenSearch 2.3.0 is here](https://opensearch.org/downloads.html#opensearch) with new capabilities for you to explore! For this release, we prioritized three new features that OpenSearch users have been asking for and that offer significant advances in performance, data durability, and usability. We’re including them as experimental features so that you have the option to deploy them as you wish or stick with the default approach to these tasks. We hope you will put these features to work and share your feedback on how they perform in your environment, what added functionality you’d like to see, and any opportunities for improvement. Read on for a look at each new feature and where you can share your impressions.

--- a/_posts/2022-09-16-security-issue-response.md
+++ b/_posts/2022-09-16-security-issue-response.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-09-16 00:00:00 -0700
 categories:
   - technical-post
+redirect_from: "/blog/technical-post/2022/09/security-issue-response/"
 ---
 
 Today we are taking the next step in our open-source journey by updating our security policy to include a process for how we respond to security issues. In proper open-source fashion, we are creating this as a [pull request](https://github.com/opensearch-project/.github/pull/90), and we are inviting everyone to take part in the discussion.

--- a/_posts/2022-09-26-opensearch-playground.md
+++ b/_posts/2022-09-26-opensearch-playground.md
@@ -7,6 +7,7 @@ authors:
 date:   2022-10-03 00:00:00 -0700
 categories:
   - community
+redirect_from: "/blog/community/2022/10/opensearch-playground/"
 ---
 
 We are excited to announce the live demo environment of OpenSearch and OpenSearch Dashboards. OpenSearch Playground provides a central location for existing and evaluating users to explore features in OpenSearch and OpenSearch Dashboards without installing or downloading anything. You can access OpenSearch Playground at [playground.opensearch.org](https://playground.opensearch.org).

--- a/_posts/2022-09-27-opensearch-supported-by-tracetest.md
+++ b/_posts/2022-09-27-opensearch-supported-by-tracetest.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-09-27 12:15:00 -0300
 categories:
   - community
+redirect_from: "/blog/community/2022/09/opensearch-supported-by-tracetest/"
 ---
 
 I am excited to announce that [Tracetest](https://tracetest.io) now supports OpenSearch! If you already use OpenSearch Trace Analytics, you can start writing tests based on your telemetry using Tracetest without having to change anything in your application. In this article, we will explain how you can start building trace-based tests right now.

--- a/_posts/2022-09-27-whatsnew-custom-geo-json.md
+++ b/_posts/2022-09-27-whatsnew-custom-geo-json.md
@@ -9,6 +9,7 @@ authors:
 date: 2022-09-27
 categories:
  - technical-post
+redirect_from: "/blog/technical-post/2022/09/whatsnew-custom-geo-json/"
 ---
 
 In [OpenSearch 2.2](https://opensearch.org/blog/releases/2022/08/opensearch-2-2-is-now-available/), we released custom GeoJSON support for region map visualizations in OpenSearch Dashboards. Custom GeoJSON enables customers to map their own GeoJSON file. Custom GeoJSON builds on the GeoShape features included in earlier releases. In this blog post, we will provide the following:

--- a/_posts/2022-10-03-hacktoberfest-2022.md
+++ b/_posts/2022-10-03-hacktoberfest-2022.md
@@ -10,7 +10,7 @@ categories:
   - community
 excerpt: |
     Learn all about how you can contribute to OpenSearch this Hacktoberfest!
-
+redirect_from: "/blog/community/2022/10/hacktoberfest-2022/"
 ---
 
 ![Hacktoberfest Logo](/assets/media/blog-images/2022-10-03-hacktoberfest-2022/hacktoberfest.png){: .img-fluid}

--- a/_posts/2022-10-05-one-million-enitities-in-one-minute.markdown
+++ b/_posts/2022-10-05-one-million-enitities-in-one-minute.markdown
@@ -11,6 +11,7 @@ authors:
 date: 2022-10-05
 categories:
  - technical-post
+redirect_from: "/blog/technical-post/2022/10/one-million-enitities-in-one-minute/"
 ---
 
 _“When you can measure what you are speaking about, and express it in numbers, you know something about it.”_

--- a/_posts/2022-10-10-Announcing-Data-Prepper-2.0.0.md
+++ b/_posts/2022-10-10-Announcing-Data-Prepper-2.0.0.md
@@ -7,6 +7,7 @@ authors:
 date: 2022-10-10 15:00:00 -0500
 categories:
   - technical-post
+redirect_from: "/blog/technical-post/2022/10/Announcing-Data-Prepper-2.0.0/"
 ---
 
 The Data Prepper maintainers are proud to announce the release of Data Prepper 2.0. This release makes 

--- a/_posts/2022-10-10-snapshot-management.md
+++ b/_posts/2022-10-10-snapshot-management.md
@@ -9,6 +9,7 @@ categories:
  - technical-post
 
 excerpt: "In version 2.1, the OpenSearch project introduced Snapshot Management (SM). SM is a way to automatically take snapshots of your cluster. While previously you had to rely on external management tools like Curator, now you can automatically back up your index data and cluster state through OpenSearch."
+redirect_from: "/blog/technical-post/2022/10/snapshot-management/"
 ---
 
 In [version 2.1](https://opensearch.org/blog/releases/2022/07/opensearch-2-1-is-available-now/), the OpenSearch project introduced Snapshot Management (SM)&mdash;a way to automatically take snapshots of your cluster. While previously you had to rely on external management tools like Curator, now you can automatically back up your index data and cluster state through OpenSearch. Just set a schedule to take snapshots every hour or every Sunday at midnight, and sit back while the snapshots are created. 

--- a/_posts/2022-10-18-Adopting-inclusive-language-across-OpenSearch.md
+++ b/_posts/2022-10-18-Adopting-inclusive-language-across-OpenSearch.md
@@ -9,6 +9,7 @@ categories:
  - technical-post
 
 excerpt: "We are removing exclusionary language from the OpenSearch Project, including from APIs, documentation, and source code. Specifically, we are replacing the non-inclusive terms \"master\" and \"blacklist/whitelist\" with inclusive language throughout the OpenSearch Project."
+redirect_from: "/blog/technical-post/2022/10/Adopting-inclusive-language-across-OpenSearch/"
 ---
 
 We are removing exclusionary language from the OpenSearch Project, including from APIs, documentation, and source code. Specifically, we are replacing the non-inclusive terms "master" and "blacklist/whitelist" with inclusive language throughout the OpenSearch Project. 

--- a/_posts/2022-10-19-asking-the-right-people-the-right-questions.md
+++ b/_posts/2022-10-19-asking-the-right-people-the-right-questions.md
@@ -8,6 +8,7 @@ categories:
  - technical-post
 excerpt: "There's no better feeling than getting some help from a living, breathing human being and finding out I'm not alone in my struggle."
 
+redirect_from: "/blog/technical-post/2022/10/asking-the-right-people-the-right-questions/"
 ---
 
 

--- a/_posts/2022-10-20-aws-knn-algorithms-workload-optimizations.markdown
+++ b/_posts/2022-10-20-aws-knn-algorithms-workload-optimizations.markdown
@@ -6,7 +6,7 @@ authors:
 date: 2022-10-19
 categories:
   - partners
-
+redirect_from: "/blog/partners/2022/10/aws-knn-algorithms-workload-optimizations/"
 ---
 
 OpenSearch partner and contributor [AWS](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/gsg.html) recently [published a blog](https://aws.amazon.com/blogs/big-data/choose-the-k-nn-algorithm-for-your-billion-scale-use-case-with-opensearch/) that focuses on the different algorithms and techniques used to perform approximate k-NN search at scales of more than a billion data points within OpenSearch. In the blog, Othmane Hamzaoui, AI/ML Specialist Solutions Architect with AWS, and Jack Mazanec, Software Dev Engineer and OpenSearch committer, explain algorithms including Hierarchical Navigable Small Worlds (HNSW), Inverted File System(IVF), and Product Quantization (PQ), and share the techniques and the memory footprint to support each of these algorithms, with examples. The post also includes the metrics and trade-offs between recall and performance, so you can choose the right algorithm for your k-NN workload at scale.  Explore the [AWS blog](https://aws.amazon.com/blogs/big-data/choose-the-k-nn-algorithm-for-your-billion-scale-use-case-with-opensearch/) and be sure to check out the benchmarking codebase for yourself in [GitHub](https://github.com/opensearch-project/k-NN/tree/1.3.1.0/benchmarks/perf-tool). 

--- a/_posts/2022-10-24-public-jenkins.markdown
+++ b/_posts/2022-10-24-public-jenkins.markdown
@@ -6,6 +6,7 @@ authors:
 date: 2022-10-24 01:01:01 -0700
 categories: 
   - community
+redirect_from: "/blog/community/2022/10/public-jenkins/"
 ---
 
 The OpenSearch Project deployed automated build, test, and release infrastructure that supports the end-to-end lifecycle of public distributions with the launch of [OpenSearch 2.3.0](https://opensearch.org/blog/releases/2022/09/opensearch-2-3-is-ready-for-download/). This includes the migration of OpenSearch Gradle check workflows that are run on every PR merge to the public infrastructure. Community members can now view logs by accessing the [build infrastructure](https://build.ci.opensearch.org/) to understand the current state of their workflows and monitor runs as needed.

--- a/_posts/2022-10-25-ltr-with-opensearch-and-metarank.markdown
+++ b/_posts/2022-10-25-ltr-with-opensearch-and-metarank.markdown
@@ -6,6 +6,7 @@ authors:
 date:   2022-10-25 1
 categories:
   - community
+redirect_from: "/blog/community/2022/10/ltr-with-opensearch-and-metarank/"
 ---
 
 [Metarank](https://github.com/metarank/metarank) is an open-source secondary ranker that can perform advanced search results by reordering the results with a [LambdaMART](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/MSR-TR-2010-82.pdf) learning to rank (LTR) model. In this post, we'll discuss why and when an LTR approach to ranking may be helpful and how Metarank implements LTR on top of OpenSearch. 

--- a/_posts/2022-10-26-OpenSearch-Project-voice-and-tone.md
+++ b/_posts/2022-10-26-OpenSearch-Project-voice-and-tone.md
@@ -6,6 +6,7 @@ authors:
 date: 2022-10-26
 categories: 
   - community
+redirect_from: "/blog/community/2022/10/OpenSearch-Project-voice-and-tone/"
 ---
 
 In the [first installment](https://opensearch.org/blog/community/2022/08/New-series-From-the-editors-desk/) of our *From the editor’s desk* series, we focused on the OpenSearch Project and inclusion, a subject that is foundational to who we are and how we talk to each other as a community. For the second installment, we’d like to focus on another subject related to community interaction: voice and tone.

--- a/_posts/2022-10-28-multiple-data-source.md
+++ b/_posts/2022-10-28-multiple-data-source.md
@@ -8,6 +8,7 @@ authors:
 date:   2022-11-16 00:00:00 -0700
 categories:
   - community
+redirect_from: "/blog/community/2022/11/multiple-data-source/"
 ---
 
 OpenSearch Dashboards' current architecture works only with a single OpenSearch cluster, and to view data in different OpenSearch clusters and to navigate between Dashboards endpoints, users must have a complete OpenSearch with Dashboards stack setup. To solve this challenge, we are excited to announce for release 2.4 the Multiple Data Sources feature. This experimental feature supports multiple data source connections in OpenSearch Dashboards.

--- a/_posts/2022-10-31-Adding-New-Distributions-to-OpenSearch-Project.md
+++ b/_posts/2022-10-31-Adding-New-Distributions-to-OpenSearch-Project.md
@@ -6,6 +6,7 @@ authors:
 date: 2022-10-31 01:01:01 -0700
 categories: 
   - community
+redirect_from: "/blog/community/2022/10/Adding-New-Distributions-to-OpenSearch-Project/"
 ---
 
 Starting with OpenSearch version 1.3.2 for 1.x, and 2.0.0 for 2.x, OpenSearch has expanded its artifacts into multiple distributions, including `TAR`, `Docker`, and `RPM`. Looking back, it has been a challenging and exciting journey to get here. 

--- a/_posts/2022-11-08-thudtest.md
+++ b/_posts/2022-11-08-thudtest.md
@@ -6,6 +6,7 @@ title: "The thud test: Measuring OpenSearch Documentation"
 date: 2022-11-11 01:01:01 -0700
 categories:
 - feature
+redirect_from: "/blog/feature/2022/11/thudtest/"
 ---
 
 When I first started my career as a technical writer about 20 years ago, success was measured by the volume of content produced. Back then, everything was printed and bound. When you dropped a stack of paper on a desk or the ground, it would make an audible *thud*. The theory went that the louder the thud, the more content you had produced, and the happier your customers were.

--- a/_posts/2022-11-09-OpenSearch-Partner-Highlight-Using-Cloaked-Search.md
+++ b/_posts/2022-11-09-OpenSearch-Partner-Highlight-Using-Cloaked-Search.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-11-14
 categories:
   - partners
+redirect_from: "/blog/partners/2022/11/OpenSearch-Partner-Highlight-Using-Cloaked-Search/"
 ---
 
 Most companies will tell you that the data they hold is well protected. They'll say it's encrypted “at rest and

--- a/_posts/2022-11-15-opensearch-2-4-is-available-today.md
+++ b/_posts/2022-11-15-opensearch-2-4-is-available-today.md
@@ -6,6 +6,7 @@ authors:
 date:   2022-11-15 12:15:00 -0700
 categories:
   - releases
+redirect_from: "/blog/releases/2022/11/opensearch-2-4-is-available-today/"
 ---
 
 OpenSearch 2.4.0 brings Windows support, security analytics, new geospatial features, and a variety of upgrades for search, analytics, and observability use cases

--- a/_posts/2022-11-17-Multiple-Authentication.md
+++ b/_posts/2022-11-17-Multiple-Authentication.md
@@ -8,6 +8,7 @@ authors:
 date: 2022-11-17 00:00:00 -0700
 categories: 
   - community
+redirect_from: "/blog/community/2022/11/Multiple-Authentication/"
 ---
 
 We’re excited to announce support for concurrent multiple authentication methods in OpenSearch Dashboards. This enhancement to the Dashboards security plugin provides a more unified and user-friendly login experience to Dashboards users, who are now able to choose a preferred option from a login UI that integrates basic authentication (username and password) and multiple single sign-on (SSO) providers for OpenID Connect (OIDC) and SAML.

--- a/_posts/2022-11-28-searchium-improve-search-performance.markdown
+++ b/_posts/2022-11-28-searchium-improve-search-performance.markdown
@@ -7,6 +7,8 @@ date: 2022-11-28
 categories:
   - partners
 
+redirect_from: /blog/partners/2022/11/searchium-improve-search-performance/
+
 ---
 
 In search, speed is key to delivering a good user experience. In a [recent blog post](https://medium.com/@noamschwartz1/bolster-opensearch-performance-with-5-simple-steps-ca7d21234f6b), Noam Schwartz of OpenSearch Project partner [Searchium.ai](https://www.searchium.ai/) explores five ways to improve search speed and cluster performance for OpenSearch. Check out “[Bolster OpenSearch performance with 5 simple steps](https://medium.com/@noamschwartz1/bolster-opensearch-performance-with-5-simple-steps-ca7d21234f6b)” for practical advice on managing your indices, optimizing cache utilization, selecting the right refresh interval, and more.


### PR DESCRIPTION
… "redirect_from" frontmatter.

Signed-off-by: Nate Boot <nateboot@amazon.com>

### Description
* Changes `_config.yml` to use a new permalink url hierarchy for blog posts. 
* Adds `redirect_from` front matter to each blog post redirecting to the new url from the old one. 
 
### Issues Resolved
I can't find it. 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
