### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,20 +1,22 @@
-## Maintainers
+## Overview
 
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
-### Current Maintainers
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Eli Fisher | [elfisher](https://github.com/elfisher) | Amazon |
-| Miki Barahmand | [AMoo-Miki](https://github.com/AMoo-Miki) | Amazon |
-| Nick Knize | [nknize](https://github.com/nknize) | Amazon |
-| Kris Freedain | [krisfreedain](https://github.com/krisfreedain) | Amazon |
-| Peter Zhu | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon |
-| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE) | Amazon |
-| David Tippett | [dtaivpp](https://github.com/dtaivpp) | Amazon |
+## Current Maintainers
 
-### Emeritus Maintainers
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Kyle J. Davis | [stockholmux](https://github.com/stockholmux) | Amazon |
+| Maintainer       | GitHub ID                                           | Affiliation |
+| ---------------- | --------------------------------------------------- | ----------- |
+| Eli Fisher       | [elfisher](https://github.com/elfisher)             | Amazon      |
+| Miki Barahmand   | [AMoo-Miki](https://github.com/AMoo-Miki)           | Amazon      |
+| Nick Knize       | [nknize](https://github.com/nknize)                 | Amazon      |
+| Kris Freedain    | [krisfreedain](https://github.com/krisfreedain)     | Amazon      |
+| Peter Zhu        | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
+| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE)             | Amazon      |
+| David Tippett    | [dtaivpp](https://github.com/dtaivpp)               | Amazon      |
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+### Emeritus
+
+| Maintainer    | GitHub ID                                     | Affiliation |
+| ------------- | --------------------------------------------- | ----------- |
+| Kyle J. Davis | [stockholmux](https://github.com/stockholmux) | Amazon      |
+


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.