### PR TITLE
Add Fanit Kolchina as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Peter Zhu        | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
 | Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE)             | Amazon      |
 | David Tippett    | [dtaivpp](https://github.com/dtaivpp)               | Amazon      |
+| Fanit Kolchina   | [kolchfa-aws](https://github.com/kolchfa-aws)       | Amazon      |
 
 ### Emeritus
 


### PR DESCRIPTION
Signed-off-by: Kris Freedain <kris@freedain.com>

### Description
from @elfisher's nomination email:  
I would like to nominate Fanit Kolchina as a maintainer on the [project-website](https://github.com/opensearch-project/project-website) repo. Fanit’s github profile can be found here: [https://github.com/kolchfa-aws](https://github.com/kolchfa-aws?tab=overview&from=2022-09-01&to=2022-09-30)
Fanit has helped contribute multiple blogs and is a regular reviewer of blogs working with authors to ensure a high quality bar of writing. E.g:
https://github.com/opensearch-project/project-website/pull/1195
https://github.com/opensearch-project/project-website/pull/987
 
I believe she will be a welcomed maintainer to this group because I believe she will be an even more active participant and will be able to be more hands on helping people incorporate feedback on the blogs they work on. Specifically, as a maintainer she will be able to directly collaborate on PRs from authors and help ensure they have a great experience contributing content which will in turn help community members be more successful and foster more community contributions.
 
### Issues Resolved
n/a

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
