### PR TITLE
Fix repeating signatures in downloads

### DIFF
--- a/_layouts/versions.html
+++ b/_layouts/versions.html
@@ -249,6 +249,7 @@ this is the built-in error checking for the version definition having missing ar
               {% endcapture %}
               {% assign artifact_extras = artifact_extras | append: artifact_extra %}
             {% endif %}
+            {% assign artifact_extra = nil %}
           {% endfor %}
         {%endfor%}
       {% endfor %}


### PR DESCRIPTION

### Description
Some of the options on the downloads page showed repeated signature verification indicators.
 
### Issues Resolved
fixes #1128

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
