### PR TITLE
2.6 alert off

### DIFF
--- a/_data/alert.yml
+++ b/_data/alert.yml
@@ -1,1 +1,1 @@
-message: "Version 2.6.0 is out! [Download](/downloads.html)"
+_message: "Version 2.6.0 is out! [Download](/downloads.html)"


### PR DESCRIPTION
### Description
Turning off the top 2.6 alert on the main page
 
### Issues Resolved
n/a

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
