### PR TITLE
Adding Data Prepper 2.1.1 and OpenSearch 1.3.9 releases. 

### DIFF
--- a/_artifacts/data-prepper/data-prepper-2.1.1-docker-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-2.1.1-docker-x64.markdown
@@ -1,0 +1,21 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-2.1.1
+platform: docker
+type: docker
+architecture: x64
+slug: data-prepper-2.1.1-docker-x64
+category: opensearch
+inline_instructions:
+- label: "Docker Hub"
+  code: docker pull opensearchproject/data-prepper:2.1.1
+  link:
+  label: View on Docker Hub
+  url: https://hub.docker.com/r/opensearchproject/data-prepper/tags?page=1&ordering=last_updated&name=2.1.1
+- label: "Amazon ECR"
+  code: docker pull public.ecr.aws/opensearchproject/data-prepper:2.1.1
+  link:
+  label: View on Amazon ECR
+  url: https://gallery.ecr.aws/opensearchproject/data-prepper
+---

--- a/_artifacts/data-prepper/data-prepper-2.1.1-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-2.1.1-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-2.1.1
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/2.1.1/opensearch-data-prepper-jdk-2.1.1-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/2.1.1/opensearch-data-prepper-jdk-2.1.1-linux-x64.tar.gz.sig
+slug: data-prepper-jdk-2.1.1-linux-x64
+category: opensearch
+---

--- a/_artifacts/data-prepper/data-prepper-2.1.1-no-jdk-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-2.1.1-no-jdk-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper-no-jdk
+version: data-prepper-2.1.1
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/2.1.1/opensearch-data-prepper-2.1.1-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/2.1.1/opensearch-data-prepper-2.1.1-linux-x64.tar.gz.sig
+slug: data-prepper-2.1.1-linux-x64
+category: opensearch
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-docker-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-docker-arm64.markdown
@@ -1,0 +1,11 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: docker
+architecture: arm64
+slug: opensearch-1.3.9-docker-arm64
+category: opensearch
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch/tags?page=1&ordering=last_updated&name=1.3.9
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-freebsd-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-freebsd-arm64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: freebsd
+architecture: arm64
+slug: opensearch-1.3.9-freebsd-arm64
+category: opensearch
+type: system-package
+freebsd_package_name: opensearch
+link: https://www.freshports.org/textproc/opensearch
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64-deb.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64-deb.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: arm64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-arm64.deb
+slug: opensearch-1.3.9-linux-arm64-deb
+category: opensearch
+type: deb
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-arm64.deb.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64-rpm.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: arm64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-arm64.rpm
+slug: opensearch-1.3.9-linux-arm64-rpm
+category: opensearch
+type: rpm
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-arm64.rpm.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64-yum.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64-yum.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: arm64
+slug: opensearch-1.3.9-linux-arm64-yum
+category: opensearch
+type: yum
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-linux-arm64.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: arm64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-arm64.tar.gz
+
+slug: opensearch-1.3.9-linux-arm64
+category: opensearch
+type: targz
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-arm64.tar.gz.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-min-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.9-min-linux-arm64.markdown
@@ -1,0 +1,15 @@
+---
+role: daemon
+artifact_id: opensearch-min
+version: 1.3.9
+platform: linux
+architecture: arm64
+slug: opensearch-1.3.9-min-linux-arm64
+category: opensearch
+type: targz
+
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch/1.3.9/opensearch-min-1.3.9-linux-arm64.tar.gz
+signature: https://artifacts.opensearch.org/releases/core/opensearch/1.3.9/opensearch-min-1.3.9-linux-arm64.tar.gz.sig
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-docker-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-docker-arm64.markdown
@@ -1,0 +1,11 @@
+---
+role: ui
+artifact_id: opensearch-dashboards
+version: 1.3.9
+platform: docker
+architecture: arm64
+slug: opensearch-dashboards-1.3.9-docker-arm64
+category: opensearch-dashboards
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch-dashboards/tags?page=1&ordering=last_updated&name=1.3.9
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64-deb.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64-deb.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: deb
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-arm64.deb
+version: 1.3.9
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-arm64-deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-arm64.deb.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64-rpm.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-arm64.rpm
+version: 1.3.9
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-arm64-rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-arm64.rpm.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64-yum.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64-yum.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: yum
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo
+version: 1.3.9
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-arm64-yum
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-linux-arm64.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-arm64.tar.gz
+version: 1.3.9
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-arm64
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-arm64.tar.gz.sig
+---
+

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-min-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.9-min-linux-arm64.markdown
@@ -1,0 +1,15 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards-min
+architecture: arm64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.9/opensearch-dashboards-min-1.3.9-linux-arm64.tar.gz
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-min-linux-arm64
+signature: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.9/opensearch-dashboards-min-1.3.9-linux-arm64.tar.gz.sig
+version: 1.3.9
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-docker-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-docker-x64.markdown
@@ -1,0 +1,11 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: docker
+architecture: x64
+slug: opensearch-1.3.9-docker-x64
+category: opensearch
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch/tags?page=1&ordering=last_updated&name=1.3.9
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-freebsd-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-freebsd-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: freebsd
+architecture: x64
+slug: opensearch-1.3.9-freebsd-x64
+category: opensearch
+type: system-package
+freebsd_package_name: opensearch
+link: https://www.freshports.org/textproc/opensearch
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64-deb.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64-deb.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-x64.deb
+slug: opensearch-1.3.9-linux-x64-deb
+category: opensearch
+type: deb
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-x64.deb.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64-rpm.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-x64.rpm
+slug: opensearch-1.3.9-linux-x64-rpm
+category: opensearch
+type: rpm
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-x64.rpm.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64-yum.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64-yum.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: x64
+slug: opensearch-1.3.9-linux-x64-yum
+category: opensearch
+type: yum
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-x64.tar.gz
+slug: opensearch-1.3.9-linux-x64
+category: opensearch
+type: targz
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-linux-x64.tar.gz.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-min-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-min-linux-x64.markdown
@@ -1,0 +1,14 @@
+---
+role: daemon
+artifact_id: opensearch-min
+version: 1.3.9
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch/1.3.9/opensearch-min-1.3.9-linux-x64.tar.gz
+slug: opensearch-1.3.9-min-linux-x64
+category: opensearch
+type: targz
+signature: https://artifacts.opensearch.org/releases/core/opensearch/1.3.9/opensearch-min-1.3.9-linux-x64.tar.gz.sig
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-windows-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.9-windows-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: windows
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-windows-x64.zip
+slug: opensearch-1.3.9-windows-x64
+category: opensearch
+type: zip
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.9/opensearch-1.3.9-windows-x64.zip.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-docker-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-docker-x64.markdown
@@ -1,0 +1,11 @@
+---
+role: ui
+artifact_id: opensearch-dashboards
+version: 1.3.9
+platform: docker
+architecture: x64
+slug: opensearch-dashboards-1.3.9-docker-x64
+category: opensearch-dashboards
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch-dashboards/tags?page=1&ordering=last_updated&name=1.3.9
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64-deb.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64-deb.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: deb
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-x64.deb
+version: 1.3.9
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-x64-deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-x64.deb.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64-rpm.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-x64.rpm
+version: 1.3.9
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-x64-rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-x64.rpm.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64-yum.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64-yum.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: yum
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo
+version: 1.3.9
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-x64-yum
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-linux-x64.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-x64.tar.gz
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-linux-x64
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-linux-x64.tar.gz.sig
+version: 1.3.9
+---
+

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-min-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-min-linux-x64.markdown
@@ -1,0 +1,15 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards-min
+architecture: x64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.9/opensearch-dashboards-min-1.3.9-linux-x64.tar.gz
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-min-linux-x64
+signature: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.9/opensearch-dashboards-min-1.3.9-linux-x64.tar.gz.sig
+version: 1.3.9
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-windows-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.9-windows-x64.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: windows
+type: zip
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-windows-x64.zip
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.9-windows-x64
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.9/opensearch-dashboards-1.3.9-windows-x64.zip.sig
+version: 1.3.9
+---
+

--- a/_artifacts/opensearch-1.3/x86/opensearch-1.3.9-freebsd-x86.markdown
+++ b/_artifacts/opensearch-1.3/x86/opensearch-1.3.9-freebsd-x86.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.9
+platform: freebsd
+architecture: x86
+slug: opensearch-1.3.9-freebsd-x86
+category: opensearch
+type: system-package
+freebsd_package_name: opensearch
+link: https://www.freshports.org/textproc/opensearch
+---

--- a/_versions/2021-07-12-opensearch-1.0.0.markdown
+++ b/_versions/2021-07-12-opensearch-1.0.0.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2021-09-01-opensearch-1.0.1.markdown
+++ b/_versions/2021-09-01-opensearch-1.0.1.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2021-10-05-opensearch-1.1.0.markdown
+++ b/_versions/2021-10-05-opensearch-1.1.0.markdown
@@ -28,7 +28,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2021-11-23-opensearch-1.2.0.markdown
+++ b/_versions/2021-11-23-opensearch-1.2.0.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2021-12-11-opensearch-1.2.1.markdown
+++ b/_versions/2021-12-11-opensearch-1.2.1.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2021-12-16-opensearch-1.2.2.markdown
+++ b/_versions/2021-12-16-opensearch-1.2.2.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2021-12-22-opensearch-1.2.3.markdown
+++ b/_versions/2021-12-22-opensearch-1.2.3.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-01-18-opensearch-1.2.4.markdown
+++ b/_versions/2022-01-18-opensearch-1.2.4.markdown
@@ -21,7 +21,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-03-17-opensearch-1.3.0.markdown
+++ b/_versions/2022-03-17-opensearch-1.3.0.markdown
@@ -21,7 +21,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-03-30-opensearch-1.3.1.markdown
+++ b/_versions/2022-03-30-opensearch-1.3.1.markdown
@@ -21,7 +21,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-05-05-opensearch-1.3.2.markdown
+++ b/_versions/2022-05-05-opensearch-1.3.2.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-05-26-opensearch-2.0.0.markdown
+++ b/_versions/2022-05-26-opensearch-2.0.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-06-09-opensearch-1.3.3.markdown
+++ b/_versions/2022-06-09-opensearch-1.3.3.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-06-16-opensearch-2.0.1.markdown
+++ b/_versions/2022-06-16-opensearch-2.0.1.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-07-07-opensearch-2.1.0.markdown
+++ b/_versions/2022-07-07-opensearch-2.1.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-07-14-opensearch-1.3.4.markdown
+++ b/_versions/2022-07-14-opensearch-1.3.4.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-08-11-opensearch-2.2.0.markdown
+++ b/_versions/2022-08-11-opensearch-2.2.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-09-01-opensearch-1.3.5.markdown
+++ b/_versions/2022-09-01-opensearch-1.3.5.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-09-01-opensearch-2.2.1.markdown
+++ b/_versions/2022-09-01-opensearch-2.2.1.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-09-14-opensearch-2.3.0.markdown
+++ b/_versions/2022-09-14-opensearch-2.3.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-10-06-opensearch-1.3.6.markdown
+++ b/_versions/2022-10-06-opensearch-1.3.6.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-11-15-opensearch-2.4.0.markdown
+++ b/_versions/2022-11-15-opensearch-2.4.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-12-13-opensearch-1.3.7.markdown
+++ b/_versions/2022-12-13-opensearch-1.3.7.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2022-12-13-opensearch-2.4.1.markdown
+++ b/_versions/2022-12-13-opensearch-2.4.1.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2023-01-24-opensearch-2.5.0.markdown
+++ b/_versions/2023-01-24-opensearch-2.5.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2023-02-02-opensearch-1.3.8.markdown
+++ b/_versions/2023-02-02-opensearch-1.3.8.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2023-02-28-opensearch-2.6.0.markdown
+++ b/_versions/2023-02-28-opensearch-2.6.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux

--- a/_versions/2023-03-16-opensearch-1.3.9.markdown
+++ b/_versions/2023-03-16-opensearch-1.3.9.markdown
@@ -1,0 +1,87 @@
+---
+date: "2023-03-16"
+product: opensearch
+version: '1.3.9'
+release_notes: https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-1.3.9.md
+version_sort: 1.3.9-ga
+components:
+  - role: daemon
+    artifact: opensearch
+    version: 1.3.9
+  - role: ui
+    artifact: opensearch-dashboards
+    version: 1.3.9
+  - role: command-line-tools
+    artifact: opensearch-cli
+    version: 1.1.0
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
+  - role: ingest
+    artifact: data-prepper
+    version: data-prepper-2.1.0
+    platform_order:
+      - docker
+      - linux
+  - role: minimal-artifacts
+    artifact: opensearch-min
+    version: 1.3.9
+  - role: minimal-artifacts
+    artifact: opensearch-dashboards-min
+    version: 1.3.9
+  - role: drivers
+    artifact: opensearch-sql-odbc
+    version: 1.1.0.1
+  - role: drivers
+    artifact: opensearch-sql-jdbc
+    version: 1.1.0.1
+sections:
+  docker-compose:
+    explanation: "downloads/opensearch-docker.markdown"
+  opensearch:
+    role: daemon
+    artifacts:
+      opensearch:
+        explanation: "downloads/opensearch-daemon.markdown"
+  opensearch-dashboards:
+    role: ui
+    artifacts:
+      opensearch-dashboards:
+        explanation: "downloads/opensearch-ui.markdown"
+  data-ingest:
+    explanation: "downloads/opensearch-data-ingest.markdown"
+    role: ingest
+    artifacts:
+      data-prepper:
+        explanation: "downloads/data-prepper.html"
+      logstash-oss-with-opensearch-output-plugin:
+        explanation: "downloads/logstash-oss-with-opensearch-output-plugin.markdown"
+  command-line-tools:
+    role: command-line-tools
+    artifacts:
+      opensearch-cli:
+        explanation: "downloads/opensearch-cli.html"
+  drivers:
+    explanation: "downloads/drivers.markdown"
+    role: drivers
+    artifacts:
+      opensearch-sql-odbc:
+        explanation: "downloads/odbc.markdown"
+      opensearch-sql-jdbc:
+        explanation: "downloads/jdbc.markdown"
+  minimal:
+    explanation: "downloads/minimal-distributions.markdown"
+    role: minimal-artifacts
+    artifacts:
+      opensearch-min:
+        explanation: "downloads/opensearch-daemon-min.markdown"
+      opensearch-dashboards-min:
+        explanation: "downloads/opensearch-ui-min.markdown"
+pretty:
+  artifacts:
+    opensearch: ''
+    opensearch-min: 'OpenSearch Minimum'
+    opensearch-dashboards: ''
+    opensearch-dashboards-min: 'OpenSearch Dashboards Minimum'
+---
+OpenSearch is open source software that uses the Apache License version 2 (ALv2). ALv2 grants you well-understood usage rights; you can use, modify, extend, embed, monetize, resell, and offer OpenSearch as part of your products and services. The source for the entire project is available on [GitHub](https://github.com/opensearch-project/) and you're welcome to build from source for customized deployments. Downloadable artifacts for OpenSearch and OpenSearch Dashboards include plugins and tools, ready for you to use with minimal configuration.

--- a/_versions/_2021-12-14-opensearch-1.1.1.markdown
+++ b/_versions/_2021-12-14-opensearch-1.1.1.markdown
@@ -25,7 +25,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.1.1
     platform_order:
       - docker
       - linux


### PR DESCRIPTION
### Description
Adding Data Prepper 2.1.1 and OpenSearch 1.3.9 releases. 
 
### Issues Resolved
N/A

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
Signed-off-by: David Tippett <dtip@amazon.com>