### PR TITLE
Added webrick.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,4 @@ end
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
 gem "rouge"
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -91,6 +92,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick
 
 BUNDLED WITH
    2.3.5


### PR DESCRIPTION
### Description

With Ruby 3.1.2 if you try to run `jekyll serve` you'll get an error.

```
osx ~/source/opensearch-project/project-website/dblock-project-website (extensibility-roadmap)$ jekyll serve
Configuration file: /Users/dblock/source/opensearch-project/project-website/dblock-project-website/_config.yml
            Source: /Users/dblock/source/opensearch-project/project-website/dblock-project-website
       Destination: /Users/dblock/source/opensearch-project/project-website/dblock-project-website/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Jekyll Feed: Generating feed for posts
   ContentModifier: disabled. Enable with JEKYLL_ALLOW_CONTENT_MODIFIER on the environment
       LinkChecker: disabled. Enable with JEKYLL_LINK_CHECKER on the environment
    ContentIndexer: disabled. Enable with JEKYLL_ALLOW_CONTENT_INDEXER on the environment
                    done in 27.816 seconds.
 Auto-regeneration: enabled for '/Users/dblock/source/opensearch-project/project-website/dblock-project-website'
                    ------------------------------------------------
      Jekyll 4.2.0   Please append `--trace` to the `serve` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
/Users/dblock/.rvm/gems/ruby-3.1.2/gems/jekyll-4.2.0/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
	from /Users/dblock/.rvm/gems/ruby-3.1.2/gems/jekyll-4.2.0/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
