### PR TITLE
Add nateynateynate as a MAINTAINER

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE)             | Amazon      |
 | David Tippett    | [dtaivpp](https://github.com/dtaivpp)               | Amazon      |
 | Fanit Kolchina   | [kolchfa-aws](https://github.com/kolchfa-aws)       | Amazon      |
+| Nate Boot        | [nateynateynate](https://github.com/nateynateynate) | Amazon      |
 
 ### Emeritus
 


### PR DESCRIPTION
### Description
Following https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#addition to update maintainer list with nominees. The maintainers have voted and agreed to this nomination and the nominee confirmed their interest in becoming co-maintainer.

Detail from nomination:
I would like to maintain we add Nate Boot as a maintainer on the project-website. He is a Developer Advocate on the OpenSearch project. Full profile here: https://github.com/nateynateynate  
He has helped on a number of 
PRs: 
https://github.com/opensearch-project/project-website/pulls?q=is%3Apr+nateynateynate
Issues: 
https://github.com/opensearch-project/project-website/issues?q=is%3Aissue+nateynateynate+
 
Some of the main highlights he has contributed to the repo already are the Hero Banner carousel, and the blog structure and URL change that resulted in a major improvement to page load times.
 
Please let me know if you approve, or have any reservations.
 
### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
