### PR TITLE
Reduce schedule of link checker and dont run on forks

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,10 +3,11 @@ name: Check Links
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 11 * * *"
+    - cron: "30 11 1,15 * *"
 
 jobs:
   check:
+    if: github.repository == ‘opensearch-project/project-website’
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Description
This commit limits the run of the link checker to not run on forks and will only check links 2x a month on the 1st and the 15th.
 
### Issues Resolved
N/A

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
