### PR TITLE
Release Data Prepper 2.2.0

### DIFF
--- a/_artifacts/data-prepper/data-prepper-2.2.0-docker-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-2.2.0-docker-x64.markdown
@@ -1,0 +1,21 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-2.2.0
+platform: docker
+type: docker
+architecture: x64
+slug: data-prepper-2.2.0-docker-x64
+category: opensearch
+inline_instructions:
+- label: "Docker Hub"
+  code: docker pull opensearchproject/data-prepper:2.2.0
+  link:
+    label: View on Docker Hub
+    url: https://hub.docker.com/r/opensearchproject/data-prepper/tags?page=1&ordering=last_updated&name=2.2.0
+- label: "Amazon ECR"
+  code: docker pull public.ecr.aws/opensearchproject/data-prepper:2.2.0
+  link:
+    label: View on Amazon ECR 
+    url: https://gallery.ecr.aws/opensearchproject/data-prepper
+---

--- a/_artifacts/data-prepper/data-prepper-2.2.0-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-2.2.0-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper
+version: data-prepper-2.2.0
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/2.2.0/opensearch-data-prepper-jdk-2.2.0-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/2.2.0/opensearch-data-prepper-jdk-2.2.0-linux-x64.tar.gz.sig
+slug: data-prepper-jdk-2.2.0-linux-x64
+category: opensearch
+---

--- a/_artifacts/data-prepper/data-prepper-2.2.0-no-jdk-linux-x64.markdown
+++ b/_artifacts/data-prepper/data-prepper-2.2.0-no-jdk-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: data-prepper-no-jdk
+version: data-prepper-2.2.0
+platform: linux
+architecture: x64
+type: targz
+artifact_url: https://artifacts.opensearch.org/data-prepper/2.2.0/opensearch-data-prepper-2.2.0-linux-x64.tar.gz
+signature: https://artifacts.opensearch.org/data-prepper/2.2.0/opensearch-data-prepper-2.2.0-linux-x64.tar.gz.sig
+slug: data-prepper-2.2.0-linux-x64
+category: opensearch
+---

--- a/_versions/2021-07-12-opensearch-1.0.0.markdown
+++ b/_versions/2021-07-12-opensearch-1.0.0.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2021-09-01-opensearch-1.0.1.markdown
+++ b/_versions/2021-09-01-opensearch-1.0.1.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2021-10-05-opensearch-1.1.0.markdown
+++ b/_versions/2021-10-05-opensearch-1.1.0.markdown
@@ -28,7 +28,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2021-11-23-opensearch-1.2.0.markdown
+++ b/_versions/2021-11-23-opensearch-1.2.0.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2021-12-11-opensearch-1.2.1.markdown
+++ b/_versions/2021-12-11-opensearch-1.2.1.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2021-12-16-opensearch-1.2.2.markdown
+++ b/_versions/2021-12-16-opensearch-1.2.2.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2021-12-22-opensearch-1.2.3.markdown
+++ b/_versions/2021-12-22-opensearch-1.2.3.markdown
@@ -27,7 +27,7 @@ components:
   -
     role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-01-18-opensearch-1.2.4.markdown
+++ b/_versions/2022-01-18-opensearch-1.2.4.markdown
@@ -21,7 +21,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-03-17-opensearch-1.3.0.markdown
+++ b/_versions/2022-03-17-opensearch-1.3.0.markdown
@@ -21,7 +21,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-03-30-opensearch-1.3.1.markdown
+++ b/_versions/2022-03-30-opensearch-1.3.1.markdown
@@ -21,7 +21,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-05-05-opensearch-1.3.2.markdown
+++ b/_versions/2022-05-05-opensearch-1.3.2.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-05-26-opensearch-2.0.0.markdown
+++ b/_versions/2022-05-26-opensearch-2.0.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-06-09-opensearch-1.3.3.markdown
+++ b/_versions/2022-06-09-opensearch-1.3.3.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-06-16-opensearch-2.0.1.markdown
+++ b/_versions/2022-06-16-opensearch-2.0.1.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-07-07-opensearch-2.1.0.markdown
+++ b/_versions/2022-07-07-opensearch-2.1.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-07-14-opensearch-1.3.4.markdown
+++ b/_versions/2022-07-14-opensearch-1.3.4.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-08-11-opensearch-2.2.0.markdown
+++ b/_versions/2022-08-11-opensearch-2.2.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-09-01-opensearch-1.3.5.markdown
+++ b/_versions/2022-09-01-opensearch-1.3.5.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-09-01-opensearch-2.2.1.markdown
+++ b/_versions/2022-09-01-opensearch-2.2.1.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-09-14-opensearch-2.3.0.markdown
+++ b/_versions/2022-09-14-opensearch-2.3.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-10-06-opensearch-1.3.6.markdown
+++ b/_versions/2022-10-06-opensearch-1.3.6.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-11-15-opensearch-2.4.0.markdown
+++ b/_versions/2022-11-15-opensearch-2.4.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-12-13-opensearch-1.3.7.markdown
+++ b/_versions/2022-12-13-opensearch-1.3.7.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2022-12-13-opensearch-2.4.1.markdown
+++ b/_versions/2022-12-13-opensearch-2.4.1.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2023-01-24-opensearch-2.5.0.markdown
+++ b/_versions/2023-01-24-opensearch-2.5.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2023-02-02-opensearch-1.3.8.markdown
+++ b/_versions/2023-02-02-opensearch-1.3.8.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2023-02-28-opensearch-2.6.0.markdown
+++ b/_versions/2023-02-28-opensearch-2.6.0.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.1
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux

--- a/_versions/2023-03-16-opensearch-1.3.9.markdown
+++ b/_versions/2023-03-16-opensearch-1.3.9.markdown
@@ -19,7 +19,7 @@ components:
     version: 8.6.1
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.1.0
+    version: data-prepper-2.2.0
     platform_order:
       - docker
       - linux


### PR DESCRIPTION
### Description
Releases Data Prepper 2.2.0

This PR includes the changes for it. Please merge after the release has completed.
We are planning to release it on 04/20/2023.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
