### PR TITLE
Reduce clicks needed to get to Slack

### DIFF
--- a/_herobanners/1.md
+++ b/_herobanners/1.md
@@ -1,3 +1,3 @@
 ---
 ---
-<a href="/blog/slack-workspace/"><img src="/assets/media/herobanners/slack-workspace.png"></a>
+<a href="/slack.html"><img src="/assets/media/herobanners/slack-workspace.png"></a>


### PR DESCRIPTION
### Description
Currently it takes 4 clicks from the slack banner to get to the actual slack page. From there it takes quite a few more clicks to get into the slack workspace. This directs users directly to the /slack.html page.
 
### Issues Resolved
N/A

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
