### PR TITLE
Moves Data Prepper above the Logstash distribution in the downloads page

### DIFF
--- a/_versions/2021-07-12-opensearch-1.0.0.markdown
+++ b/_versions/2021-07-12-opensearch-1.0.0.markdown
@@ -22,15 +22,15 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-09-01-opensearch-1.0.1.markdown
+++ b/_versions/2021-09-01-opensearch-1.0.1.markdown
@@ -22,15 +22,15 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-10-05-opensearch-1.1.0.markdown
+++ b/_versions/2021-10-05-opensearch-1.1.0.markdown
@@ -23,15 +23,15 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-11-23-opensearch-1.2.0.markdown
+++ b/_versions/2021-11-23-opensearch-1.2.0.markdown
@@ -22,15 +22,15 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-11-opensearch-1.2.1.markdown
+++ b/_versions/2021-12-11-opensearch-1.2.1.markdown
@@ -22,15 +22,15 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-16-opensearch-1.2.2.markdown
+++ b/_versions/2021-12-16-opensearch-1.2.2.markdown
@@ -22,15 +22,15 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-22-opensearch-1.2.3.markdown
+++ b/_versions/2021-12-22-opensearch-1.2.3.markdown
@@ -22,15 +22,15 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2022-01-18-opensearch-1.2.4.markdown
+++ b/_versions/2022-01-18-opensearch-1.2.4.markdown
@@ -17,14 +17,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.2.4

--- a/_versions/2022-03-17-opensearch-1.3.0.markdown
+++ b/_versions/2022-03-17-opensearch-1.3.0.markdown
@@ -17,14 +17,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.0

--- a/_versions/2022-03-30-opensearch-1.3.1.markdown
+++ b/_versions/2022-03-30-opensearch-1.3.1.markdown
@@ -17,14 +17,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.1

--- a/_versions/2022-05-05-opensearch-1.3.2.markdown
+++ b/_versions/2022-05-05-opensearch-1.3.2.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.2

--- a/_versions/2022-05-26-opensearch-2.0.0.markdown
+++ b/_versions/2022-05-26-opensearch-2.0.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.0.0

--- a/_versions/2022-06-09-opensearch-1.3.3.markdown
+++ b/_versions/2022-06-09-opensearch-1.3.3.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.3

--- a/_versions/2022-06-16-opensearch-2.0.1.markdown
+++ b/_versions/2022-06-16-opensearch-2.0.1.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.0.1

--- a/_versions/2022-07-07-opensearch-2.1.0.markdown
+++ b/_versions/2022-07-07-opensearch-2.1.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.1.0

--- a/_versions/2022-07-14-opensearch-1.3.4.markdown
+++ b/_versions/2022-07-14-opensearch-1.3.4.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.4

--- a/_versions/2022-08-11-opensearch-2.2.0.markdown
+++ b/_versions/2022-08-11-opensearch-2.2.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.2.0

--- a/_versions/2022-09-01-opensearch-1.3.5.markdown
+++ b/_versions/2022-09-01-opensearch-1.3.5.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.5

--- a/_versions/2022-09-01-opensearch-2.2.1.markdown
+++ b/_versions/2022-09-01-opensearch-2.2.1.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.2.1

--- a/_versions/2022-09-14-opensearch-2.3.0.markdown
+++ b/_versions/2022-09-14-opensearch-2.3.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.3.0

--- a/_versions/2022-10-06-opensearch-1.3.6.markdown
+++ b/_versions/2022-10-06-opensearch-1.3.6.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.6

--- a/_versions/2022-11-15-opensearch-2.4.0.markdown
+++ b/_versions/2022-11-15-opensearch-2.4.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.4.0

--- a/_versions/2022-12-13-opensearch-1.3.7.markdown
+++ b/_versions/2022-12-13-opensearch-1.3.7.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.7

--- a/_versions/2022-12-13-opensearch-2.4.1.markdown
+++ b/_versions/2022-12-13-opensearch-2.4.1.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.4.1

--- a/_versions/2023-01-24-opensearch-2.5.0.markdown
+++ b/_versions/2023-01-24-opensearch-2.5.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.5.0

--- a/_versions/2023-02-02-opensearch-1.3.8.markdown
+++ b/_versions/2023-02-02-opensearch-1.3.8.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.8

--- a/_versions/2023-02-28-opensearch-2.6.0.markdown
+++ b/_versions/2023-02-28-opensearch-2.6.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.6.0

--- a/_versions/2023-03-16-opensearch-1.3.9.markdown
+++ b/_versions/2023-03-16-opensearch-1.3.9.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.9

--- a/_versions/2023-05-02-opensearch-2.7.0.markdown
+++ b/_versions/2023-05-02-opensearch-2.7.0.markdown
@@ -15,14 +15,14 @@ components:
     artifact: opensearch-cli
     version: 1.1.0
   - role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  - role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
       - docker
       - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.7.0

--- a/_versions/_2021-12-14-opensearch-1.1.1.markdown
+++ b/_versions/_2021-12-14-opensearch-1.1.1.markdown
@@ -20,10 +20,6 @@ components:
     version: 1.1.0
   -
     role: ingest
-    artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
-  -
-    role: ingest
     artifact: data-prepper
     version: data-prepper-2.2.1
     platform_order:
@@ -33,6 +29,10 @@ components:
       - windows
       - freebsd
       - java
+  -
+    role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
   -
     role: minimal-artifacts
     artifact: opensearch-min


### PR DESCRIPTION
### Description

This PR moves Data Prepper above the Logstash on the downloads page for all versions of OpenSearch.

<img width="1045" alt="ingest-tools-download" src="https://github.com/opensearch-project/project-website/assets/293424/bc22c785-e391-4639-85e0-8cc31e970b84">

 
### Issues Resolved

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
