### PR TITLE
Fixing new file location to account for new partner page in pr-maker …

### DIFF
--- a/assets/js/mod/pr-maker.js
+++ b/assets/js/mod/pr-maker.js
@@ -65,7 +65,7 @@ link: ${companyLink}
                 $('#createPR')
                     .attr('href',template);
                 $('#createPartnerPR')
-                    .attr('href',template);
+                    .attr('href',partnertemplate);
             };
             $('.active-input').change(createUrl);
 

--- a/assets/js/mod/pr-maker.js
+++ b/assets/js/mod/pr-maker.js
@@ -59,9 +59,12 @@ link: ${companyLink}
                 let filename = encodeURIComponent(fileName);
                 let body = encodeURIComponent(body_markdown);
                 template = `https://github.com/opensearch-project/project-website/new/main/_community_projects?message=${message}&description=${dco}&filename=${filename}&target_branch=${branch}&value=${body}`;
+                partnertemplate = `https://github.com/opensearch-project/project-website/new/main/_partners?message=${message}&description=${dco}&filename=${filename}&target_branch=${branch}&value=${body}`;
 
 
                 $('#createPR')
+                    .attr('href',template);
+                $('#createPartnerPR')
                     .attr('href',template);
             };
             $('.active-input').change(createUrl);

--- a/new-partner.html
+++ b/new-partner.html
@@ -41,5 +41,5 @@ primary_title: 'New Partner'
 
 
 
-    <a href="#" target="_blank" class="cta create-pr" id="createPR">Create PR</a> 
+    <a href="#" target="_blank" class="cta create-pr" id="createPartnerPR">Create PR</a> 
 </form>


### PR DESCRIPTION
…mod.

### Description
Changes the destination of the new file started by the prmaker mod when clicking 'Create PR' on the new partners page.

### Issues Resolved
#1606 

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
