### PR TITLE
Fix next Community Meeting Time Zone

### DIFF
--- a/_events/2023-0523.markdown
+++ b/_events/2023-0523.markdown
@@ -1,7 +1,7 @@
 ---
 
 eventdate: 2023-05-23T15:00
-tz: UTC -8
+tz: UTC -7
 title: OpenSearch Community Meeting - 2023-05-23
 online: true
 signup:


### PR DESCRIPTION
The event on https://opensearch.org/events/2023-0523/ currently says:

![Date: Tue, May 23, 2023 Time: 15:00 (UTC -8)
](https://github.com/opensearch-project/project-website/assets/148721/aaf4228f-b462-4ab8-90a0-7d0ddc44796b)

Translated to my Time Zone (UTC-10), this is:

> Date: Tue, May 23, 2023
> Time: 13:00 (UTC -10)

But the meetup page says:

![Tuesday, May 23, 2023 at 12:00 PM to Tuesday, May 23, 2023 at 1:00 PM UTC−10](https://github.com/opensearch-project/project-website/assets/148721/9e3de8be-38c7-4785-b5f9-eb6618ac49b5)

So one hour offset: from 12:00 to 13:00 on meetup and 13:00 to 14:00 on the website.

Assuming the time-zone is in fact "PDT" which is "UTC-7" or "UTC-8"
depending on Daylight Saving Time, this should be set to "UTC-7".
