### PR TITLE
Localize the date and time of events

### DIFF
--- a/_events/2021-early-july.markdown
+++ b/_events/2021-early-july.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-07-12T10:00
-tz: UTC -7
+eventdate: 2021-07-12 10:00:00 -0700
 title: OpenSearch Community Meeting - Early July
 online: true
 signup:

--- a/_events/2021-early-june.markdown
+++ b/_events/2021-early-june.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-06-01T09:00
-tz: UTC -7
+eventdate: 2021-06-01 09:00:00 -0700
 title: OpenSearch Community Meeting - Early June
 online: true
 signup:

--- a/_events/2021-late-july.markdown
+++ b/_events/2021-late-july.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-07-27T09:00
-tz: UTC -7
+eventdate: 2021-07-27 09:00:00 -0700
 title: OpenSearch Community Meeting - Late July
 online: true
 signup:

--- a/_events/2021-late-june.markdown
+++ b/_events/2021-late-june.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-06-29T09:00
-tz: UTC -7
+eventdate: 2021-06-29 09:00:00 -0700
 title: OpenSearch Community Meeting - Late June
 online: true
 signup:

--- a/_events/2021-may-late.markdown
+++ b/_events/2021-may-late.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-05-18T09:00
-tz: UTC -7
+eventdate: 2021-05-18 09:00:00 -0700
 title: OpenSearch Community Meeting - Late May
 online: true
 signup:

--- a/_events/2021-mid-june.markdown
+++ b/_events/2021-mid-june.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-06-14T10:00
-tz: UTC -7
+eventdate: 2021-06-14 10:00:00 -0700
 title: OpenSearch Community Meeting - Mid June
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_dec.markdown
+++ b/_events/2021-opensearch_community_meeting_dec.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-12-14T09:00
-tz: UTC -8
+eventdate: 2021-12-14 09:00:00 -0800
 title: OpenSearch Community Meeting - Dec
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_early_august.markdown
+++ b/_events/2021-opensearch_community_meeting_early_august.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-08-09T10:00
-tz: UTC -7
+eventdate: 2021-08-09 10:00:00 -0700
 title: OpenSearch Community Meeting - Early August
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_early_nov.markdown
+++ b/_events/2021-opensearch_community_meeting_early_nov.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-11-01T10:00
-tz: UTC -7
+eventdate: 2021-11-01 10:00:00 -0700
 title: OpenSearch Community Meeting - Early Nov
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_early_oct.markdown
+++ b/_events/2021-opensearch_community_meeting_early_oct.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-10-04T10:00
-tz: UTC -7
+eventdate: 2021-10-04 10:00:00 -0700
 title: OpenSearch Community Meeting - Early Oct
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_early_sept.markdown
+++ b/_events/2021-opensearch_community_meeting_early_sept.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-09-07T09:00
-tz: UTC -7
+eventdate: 2021-09-07 09:00:00 -0700
 title: OpenSearch Community Meeting - Early Sept
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_late_august.markdown
+++ b/_events/2021-opensearch_community_meeting_late_august.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-08-24T09:00
-tz: UTC -7
+eventdate: 2021-08-24 09:00:00 -0700
 title: OpenSearch Community Meeting - Late August
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_late_nov.markdown
+++ b/_events/2021-opensearch_community_meeting_late_nov.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-11-16T09:00
-tz: UTC -8
+eventdate: 2021-11-16 09:00:00 -0800
 title: OpenSearch Community Meeting - Late Nov
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_late_oct.markdown
+++ b/_events/2021-opensearch_community_meeting_late_oct.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-10-19T09:00
-tz: UTC -7
+eventdate: 2021-10-19 09:00:00 -0700
 title: OpenSearch Community Meeting - Late Oct
 online: true
 signup:

--- a/_events/2021-opensearch_community_meeting_late_sept.markdown
+++ b/_events/2021-opensearch_community_meeting_late_sept.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2021-09-21T09:00
-tz: UTC -7
+eventdate: 2021-09-21 09:00:00 -0700
 title: OpenSearch Community Meeting - Late Sept
 online: true
 signup:

--- a/_events/2022-0104.markdown
+++ b/_events/2022-0104.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-01-04T07:00
-tz: UTC -8
+eventdate: 2022-01-04 07:00:00 -0800
 title: OpenSearch Community Meeting - 2022-01-04
 online: true
 signup:

--- a/_events/2022-0111.markdown
+++ b/_events/2022-0111.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-01-11T07:00
-tz: UTC -8
+eventdate: 2022-01-11 07:00:00 -0800
 title: OpenSearch Community Meeting - 2022-01-11 - open office hour
 online: true
 signup:

--- a/_events/2022-0118.markdown
+++ b/_events/2022-0118.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-01-18T09:00
-tz: UTC -8
+eventdate: 2022-01-18 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-01-18
 online: true
 signup:

--- a/_events/2022-0124.markdown
+++ b/_events/2022-0124.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-01-24T09:00
-tz: UTC -8
+eventdate: 2022-01-24 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-01-24 - open office hour
 online: true
 signup:

--- a/_events/2022-0201.markdown
+++ b/_events/2022-0201.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-02-01T07:00
-tz: UTC -8
+eventdate: 2022-02-01 07:00:00 -0800
 title: OpenSearch Community Meeting - 2022-02-01
 online: true
 signup:

--- a/_events/2022-0208.markdown
+++ b/_events/2022-0208.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-02-08T07:00
-tz: UTC -8
+eventdate: 2022-02-08 07:00:00 -0800
 title: OpenSearch Community Meeting - 2022-02-08 - open office hour
 online: true
 signup:

--- a/_events/2022-0214.markdown
+++ b/_events/2022-0214.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-02-14T09:00
-tz: UTC -8
+eventdate: 2022-02-14 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-02-14
 online: true
 signup:

--- a/_events/2022-0221.markdown
+++ b/_events/2022-0221.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-02-21T09:00
-tz: UTC -8
+eventdate: 2022-02-21 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-02-21 - open office hour
 online: true
 signup:

--- a/_events/2022-0301.markdown
+++ b/_events/2022-0301.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-03-01T15:00
-tz: UTC -8
+eventdate: 2022-03-01 15:00:00 -0800
 title: OpenSearch Community Meeting - 2022-03-01
 online: true
 signup:

--- a/_events/2022-0308.markdown
+++ b/_events/2022-0308.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-03-08T15:00
-tz: UTC -8
+eventdate: 2022-03-08 15:00:00 -0800
 title: OpenSearch Community Meeting - 2022-03-08 - open office hour
 online: true
 signup:

--- a/_events/2022-0314.markdown
+++ b/_events/2022-0314.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-03-14T09:00
-tz: UTC -8
+eventdate: 2022-03-14 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-03-14
 online: true
 signup:

--- a/_events/2022-0321.markdown
+++ b/_events/2022-0321.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-03-21T09:00
-tz: UTC -8
+eventdate: 2022-03-21 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-03-21 - open office hour
 online: true
 signup:

--- a/_events/2022-0329.markdown
+++ b/_events/2022-0329.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-03-29T07:00
-tz: UTC -8
+eventdate: 2022-03-29 07:00:00 -0800
 title: OpenSearch Community Meeting - 2022-03-29
 online: true
 signup:

--- a/_events/2022-0405.markdown
+++ b/_events/2022-0405.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-04-05T07:00
-tz: UTC -8
+eventdate: 2022-04-05 07:00:00 -0800
 title: OpenSearch Community Meeting - 2022-04-05 - open office hour
 online: true
 signup:

--- a/_events/2022-0411.markdown
+++ b/_events/2022-0411.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-04-11T09:00
-tz: UTC -8
+eventdate: 2022-04-11 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-04-11
 online: true
 signup:

--- a/_events/2022-0418.markdown
+++ b/_events/2022-0418.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-04-18T09:00
-tz: UTC -8
+eventdate: 2022-04-18 09:00:00 -0800
 title: OpenSearch Community Meeting - 2022-04-18 - open office hour
 online: true
 signup:

--- a/_events/2022-0426.markdown
+++ b/_events/2022-0426.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2022-04-26T015:00
+eventdate: 2022-04-26T15:00
 tz: UTC -8
 title: OpenSearch Community Meeting - 2022-04-26
 online: true

--- a/_events/2022-0426.markdown
+++ b/_events/2022-0426.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-04-26T15:00
-tz: UTC -8
+eventdate: 2022-04-26 15:00:00 -0800
 title: OpenSearch Community Meeting - 2022-04-26
 online: true
 signup:

--- a/_events/2022-0503.markdown
+++ b/_events/2022-0503.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2022-05-03T015:00
+eventdate: 2022-05-03T15:00
 tz: UTC -7
 title: OpenSearch Community Meeting - 2022-05-03
 online: true

--- a/_events/2022-0503.markdown
+++ b/_events/2022-0503.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-05-03T15:00
-tz: UTC -7
+eventdate: 2022-05-03 15:00:00 -0700
 title: OpenSearch Community Meeting - 2022-05-03
 online: true
 signup:

--- a/_events/2022-0509.markdown
+++ b/_events/2022-0509.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-05-09T09:00
-tz: UTC -7
+eventdate: 2022-05-09 09:00:00 -0700
 title: OpenSearch Community Meeting - 2022-05-09
 online: true
 signup:

--- a/_events/2022-0516.markdown
+++ b/_events/2022-0516.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-05-16T09:00
-tz: UTC -7
+eventdate: 2022-05-16 09:00:00 -0700
 title: OpenSearch Community Meeting - 2022-05-16
 online: true
 signup:

--- a/_events/2022-0524.markdown
+++ b/_events/2022-0524.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-05-24T07:00
-tz: UTC -7
+eventdate: 2022-05-24 07:00:00 -0700
 title: OpenSearch Community Meeting - 2022-05-24
 online: true
 signup:

--- a/_events/2022-0531.markdown
+++ b/_events/2022-0531.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-05-31T07:00
-tz: UTC -7
+eventdate: 2022-05-31 07:00:00 -0700
 title: OpenSearch Community Meeting - 2022-05-31
 online: true
 signup:

--- a/_events/2022-0606.markdown
+++ b/_events/2022-0606.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-06-06T09:00
-tz: UTC -7
+eventdate: 2022-06-06 09:00:00 -0700
 title: OpenSearch Community Meeting - 2022-06-06
 online: true
 signup:

--- a/_events/2022-0613.markdown
+++ b/_events/2022-0613.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-06-13T09:00
-tz: UTC -7
+eventdate: 2022-06-13 09:00:00 -0700
 title: OpenSearch Community Meeting - 2022-06-13
 online: true
 signup:

--- a/_events/2022-0621.markdown
+++ b/_events/2022-0621.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-06-22T15:00
-tz: UTC -7
+eventdate: 2022-06-22 15:00:00 -0700
 title: OpenSearch Community Meeting - 2022-06-22
 online: true
 signup:

--- a/_events/2022-0628.markdown
+++ b/_events/2022-0628.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-06-28T15:00
-tz: UTC -7
+eventdate: 2022-06-28 15:00:00 -0700
 title: OpenSearch Community Meeting - 2022-06-28
 online: true
 signup:

--- a/_events/2022-0705.markdown
+++ b/_events/2022-0705.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-07-05T09:00
-tz: UTC -7
+eventdate: 2022-07-05 09:00:00 -0700
 title: OpenSearch Community Meeting - 2022-07-05
 online: true
 signup:

--- a/_events/2022-0712.markdown
+++ b/_events/2022-0712.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-07-12T09:00
-tz: UTC -7
+eventdate: 2022-07-12 09:00:00 -0700
 title: OpenSearch Community Meeting - 2022-07-12
 online: true
 signup:

--- a/_events/2022-0719.markdown
+++ b/_events/2022-0719.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-07-19T07:00
-tz: UTC -7
+eventdate: 2022-07-19 07:00:00 -0700
 title: OpenSearch Community Meeting - 2022-07-19
 online: true
 signup:

--- a/_events/2022-0802.markdown
+++ b/_events/2022-0802.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-08-02T08:00
-tz: UTC -7
+eventdate: 2022-08-02 08:00:00 -0700
 title: OpenSearch Community Meeting - 2022-08-02
 online: true
 signup:

--- a/_events/2022-0816.markdown
+++ b/_events/2022-0816.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-08-16T15:00
-tz: UTC -7
+eventdate: 2022-08-16 15:00:00 -0700
 title: OpenSearch Community Meeting - 2022-08-16
 online: true
 signup:

--- a/_events/2022-0830.markdown
+++ b/_events/2022-0830.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-08-30T08:00
-tz: UTC -7
+eventdate: 2022-08-30 08:00:00 -0700
 title: OpenSearch Community Meeting - 2022-08-30
 online: true
 signup:

--- a/_events/2022-0913.markdown
+++ b/_events/2022-0913.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-09-13T15:00
-tz: UTC -7
+eventdate: 2022-09-13 15:00:00 -0700
 title: OpenSearch Community Meeting - 2022-09-13
 online: true
 signup:

--- a/_events/2022-0921-opensearchcon.markdown
+++ b/_events/2022-0921-opensearchcon.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-09-21T10:00
-tz: UTC -7
+eventdate: 2022-09-21 10:00:00 -0700
 title: OpenSearchCon - 2022-09-21
 online: 
 signup:

--- a/_events/2022-0927.markdown
+++ b/_events/2022-0927.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-09-27T08:00
-tz: UTC -7
+eventdate: 2022-09-27 08:00:00 -0700
 title: OpenSearch Community Meeting - 2022-09-27
 online: true
 signup:

--- a/_events/2022-1011.markdown
+++ b/_events/2022-1011.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-10-11T15:00
-tz: UTC -7
+eventdate: 2022-10-11 15:00:00 -0700
 title: OpenSearch Community Meeting - 2022-10-11
 online: true
 signup:

--- a/_events/2022-1017-dev-triage-security.markdown
+++ b/_events/2022-1017-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-10-17T12:00
-tz: UTC -7
+eventdate: 2022-10-17 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-10-17
 online: true
 signup:

--- a/_events/2022-1024-dev-triage-security.markdown
+++ b/_events/2022-1024-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-10-24T12:00
-tz: UTC -7
+eventdate: 2022-10-24 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-10-24
 online: true
 signup:

--- a/_events/2022-1024-open-observability-day.markdown
+++ b/_events/2022-1024-open-observability-day.markdown
@@ -3,6 +3,7 @@
 eventdate: 2022-10-24 08:00:00 -0400
 title: Kubecon Open Observability Day - 2022-10-24
 online: false
+tz: America/Detroit
 signup:
     url: https://events.linuxfoundation.org/open-observability-day-north-america/
     title: Meet us there!

--- a/_events/2022-1024-open-observability-day.markdown
+++ b/_events/2022-1024-open-observability-day.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-10-24T08:00
-tz: UTC -4
+eventdate: 2022-10-24 08:00:00 -0400
 title: Kubecon Open Observability Day - 2022-10-24
 online: false
 signup:

--- a/_events/2022-1025.markdown
+++ b/_events/2022-1025.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-10-25T08:00
-tz: UTC -7
+eventdate: 2022-10-25 08:00:00 -0700
 title: OpenSearch Community Meeting - 2022-10-25
 online: true
 signup:

--- a/_events/2022-1031-dev-triage-security.markdown
+++ b/_events/2022-1031-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-10-31T12:00
-tz: UTC -7
+eventdate: 2022-10-31 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-10-31
 online: true
 signup:

--- a/_events/2022-1107-dev-triage-security.markdown
+++ b/_events/2022-1107-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-11-07T12:00
-tz: UTC -7
+eventdate: 2022-11-07 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-11-07
 online: true
 signup:

--- a/_events/2022-1107-ubuntu-summit.markdown
+++ b/_events/2022-1107-ubuntu-summit.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-11-07T08:00
-tz: UTC +2
+eventdate: 2022-11-07 08:00:00 +0200
 title: Ubuntu Summit - 2022-11-07 through 11-09
 online: false
 signup:

--- a/_events/2022-1107-ubuntu-summit.markdown
+++ b/_events/2022-1107-ubuntu-summit.markdown
@@ -3,6 +3,7 @@
 eventdate: 2022-11-07 08:00:00 +0200
 title: Ubuntu Summit - 2022-11-07 through 11-09
 online: false
+tz: Europe/Prague
 signup:
     url: https://events.canonical.com/event/2/
     title: Meet us there!

--- a/_events/2022-1114-dev-triage-security.markdown
+++ b/_events/2022-1114-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-11-14T12:00
-tz: UTC -7
+eventdate: 2022-11-14 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-11-14
 online: true
 signup:

--- a/_events/2022-1122.markdown
+++ b/_events/2022-1122.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-11-22T08:00
-tz: UTC -7
+eventdate: 2022-11-22 08:00:00 -0700
 title: OpenSearch Community Meeting - 2022-11-22
 online: true
 signup:

--- a/_events/2022-1128-dev-triage-security.markdown
+++ b/_events/2022-1128-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-11-28T12:00
-tz: UTC -7
+eventdate: 2022-11-28 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-11-28
 online: true
 signup:

--- a/_events/2022-1205-dev-triage-security.markdown
+++ b/_events/2022-1205-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-12-05T12:00
-tz: UTC -7
+eventdate: 2022-12-05 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-12-05
 online: true
 signup:

--- a/_events/2022-1206.markdown
+++ b/_events/2022-1206.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-12-06T15:00
-tz: UTC -8
+eventdate: 2022-12-06 15:00:00 -0800
 title: OpenSearch Community Meeting - 2022-12-06
 online: true
 signup:

--- a/_events/2022-1212-dev-triage-security.markdown
+++ b/_events/2022-1212-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-12-12T12:00
-tz: UTC -7
+eventdate: 2022-12-12 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-12-12
 online: true
 signup:

--- a/_events/2022-1219-dev-triage-security.markdown
+++ b/_events/2022-1219-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-12-19T12:00
-tz: UTC -7
+eventdate: 2022-12-19 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2022-12-19
 online: true
 signup:

--- a/_events/2022-1220.markdown
+++ b/_events/2022-1220.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2022-12-20T08:00
-tz: UTC -8
+eventdate: 2022-12-20 08:00:00 -0800
 title: OpenSearch Community Meeting - 2022-12-20
 online: true
 signup:

--- a/_events/2023-0109-dev-triage-security.markdown
+++ b/_events/2023-0109-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-01-09T12:00
-tz: UTC -8
+eventdate: 2023-01-09 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-01-09
 online: true
 signup:

--- a/_events/2023-0116-dev-triage-security.markdown
+++ b/_events/2023-0116-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-01-17T12:00
-tz: UTC -8
+eventdate: 2023-01-17 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-01-17
 online: true
 signup:

--- a/_events/2023-0117.markdown
+++ b/_events/2023-0117.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-01-17T08:00
-tz: UTC -8
+eventdate: 2023-01-17 08:00:00 -0800
 title: OpenSearch Community Meeting - 2023-01-17
 online: true
 signup:

--- a/_events/2023-0123-dev-triage-security.markdown
+++ b/_events/2023-0123-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-01-23T12:00
-tz: UTC -8
+eventdate: 2023-01-23 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-01-23
 online: true
 signup:

--- a/_events/2023-0124-finding-the-right-things.markdown
+++ b/_events/2023-0124-finding-the-right-things.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-01-24T13:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -5
+eventdate: 2023-01-24 13:00:00 -0500
 # the title - this is how it will show up in listing and headings on the site:
 title: Data Ops Poland - Finding the Right Things with OpenSearch
 # if your event has an online component, put it here:

--- a/_events/2023-0130-dev-triage-security.markdown
+++ b/_events/2023-0130-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-01-30T12:00
-tz: UTC -8
+eventdate: 2023-01-30 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-01-30
 online: true
 signup:

--- a/_events/2023-0131.markdown
+++ b/_events/2023-0131.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-01-31T15:00
-tz: UTC -8
+eventdate: 2023-01-31 15:00:00 -0800
 title: OpenSearch Community Meeting - 2023-01-31
 online: true
 signup:

--- a/_events/2023-0205-opensearch-at-fosdem23 copy.markdown
+++ b/_events/2023-0205-opensearch-at-fosdem23 copy.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-02-05T16:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC +1
+eventdate: 2023-02-05 16:00:00 +0100
 # the title - this is how it will show up in listing and headings on the site:
 title: FOSDEM - Python Logging Like Your Job Depends on It
 # if your event has an online component, put it here:

--- a/_events/2023-0206-dev-triage-security.markdown
+++ b/_events/2023-0206-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-02-06T12:00
-tz: UTC -8
+eventdate: 2023-02-06 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-02-06
 online: true
 signup:

--- a/_events/2023-0213-dev-triage-security.markdown
+++ b/_events/2023-0213-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-02-13T12:00
-tz: UTC -8
+eventdate: 2023-02-13 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-02-13
 online: true
 signup:

--- a/_events/2023-0214.markdown
+++ b/_events/2023-0214.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-02-14T08:00
-tz: UTC -8
+eventdate: 2023-02-14 08:00:00 -0800
 title: OpenSearch Community Meeting - 2023-02-14
 online: true
 signup:

--- a/_events/2023-0220-dev-triage-security.markdown
+++ b/_events/2023-0220-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-02-20T12:00
-tz: UTC -8
+eventdate: 2023-02-20 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-02-20
 online: true
 signup:

--- a/_events/2023-0227-dev-triage-security.markdown
+++ b/_events/2023-0227-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-02-27T12:00
-tz: UTC -8
+eventdate: 2023-02-27 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-02-27
 online: true
 signup:

--- a/_events/2023-0228.markdown
+++ b/_events/2023-0228.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-02-28T15:00
-tz: UTC -8
+eventdate: 2023-02-28 15:00:00 -0800
 title: OpenSearch Community Meeting - 2023-02-28
 online: true
 signup:

--- a/_events/2023-0306-dev-triage-security.markdown
+++ b/_events/2023-0306-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-03-06T12:00
-tz: UTC -8
+eventdate: 2023-03-06 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-03-06
 online: true
 signup:

--- a/_events/2023-0307-awsopensearch-unplugged.markdown
+++ b/_events/2023-0307-awsopensearch-unplugged.markdown
@@ -3,6 +3,7 @@
 eventdate: 2023-03-07 09:00:00 -0500
 title: Partner Event - OpenSearch Unplugged - Observability and Search 
 online: false
+tz: America/New_York
 signup:
     url: https://opensearchunplugged3923.splashthat.com/
     title: Register Now

--- a/_events/2023-0307-awsopensearch-unplugged.markdown
+++ b/_events/2023-0307-awsopensearch-unplugged.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-03-07T09:00
-tz: UTC -5
+eventdate: 2023-03-07 09:00:00 -0500
 title: Partner Event - OpenSearch Unplugged - Observability and Search 
 online: false
 signup:

--- a/_events/2023-0313-dev-triage-security.markdown
+++ b/_events/2023-0313-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-03-13T12:00
-tz: UTC -8
+eventdate: 2023-03-13 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-03-13
 online: true
 signup:

--- a/_events/2023-0314.markdown
+++ b/_events/2023-0314.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-03-14T08:00
-tz: UTC -8
+eventdate: 2023-03-14 08:00:00 -0800
 title: OpenSearch Community Meeting - 2023-03-14
 online: true
 signup:

--- a/_events/2023-0320-dev-triage-security.markdown
+++ b/_events/2023-0320-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-03-20T12:00
-tz: UTC -8
+eventdate: 2023-03-20 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-03-20
 online: true
 signup:

--- a/_events/2023-0323-fluent-community.markdown
+++ b/_events/2023-0323-fluent-community.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2023-03-23T16:00
-tz: UTC -4
+eventdate: 2023-03-23 16:00:00 -0400
 title: Fluent Community Meeting
 online: true
 signup:

--- a/_events/2023-0327-dev-triage-security.markdown
+++ b/_events/2023-0327-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-03-27T12:00
-tz: UTC -8
+eventdate: 2023-03-27 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-03-27
 online: true
 signup:

--- a/_events/2023-0328.markdown
+++ b/_events/2023-0328.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-03-28T15:00
-tz: UTC -8
+eventdate: 2023-03-28 15:00:00 -0800
 title: OpenSearch Community Meeting - 2023-03-28
 online: true
 signup:

--- a/_events/2023-0403-dev-triage-security.markdown
+++ b/_events/2023-0403-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-03T12:00
-tz: UTC -8
+eventdate: 2023-04-03 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-04-03
 online: true
 signup:

--- a/_events/2023-0406-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0406-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-06T08:00
-tz: UTC -8
+eventdate: 2023-04-06 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0406
 online: true
 signup:

--- a/_events/2023-0406-fluent-community.markdown
+++ b/_events/2023-0406-fluent-community.markdown
@@ -1,6 +1,5 @@
 ---
-eventdate: 2023-04-06T16:00
-tz: UTC -4
+eventdate: 2023-04-06 16:00:00 -0400
 title: Fluent Community Meeting
 online: true
 signup:

--- a/_events/2023-0410-dev-triage-security.markdown
+++ b/_events/2023-0410-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-10T12:00
-tz: UTC -8
+eventdate: 2023-04-10 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-04-10
 online: true
 signup:

--- a/_events/2023-0411.markdown
+++ b/_events/2023-0411.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-11T08:00
-tz: UTC -8
+eventdate: 2023-04-11 08:00:00 -0800
 title: OpenSearch Community Meeting - 2023-04-11
 online: true
 signup:

--- a/_events/2023-0417-dev-triage-security.markdown
+++ b/_events/2023-0417-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-17T12:00
-tz: UTC -8
+eventdate: 2023-04-17 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-04-17
 online: true
 signup:

--- a/_events/2023-0420-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0420-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-20T08:00
-tz: UTC -8
+eventdate: 2023-04-20 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0420
 online: true
 signup:

--- a/_events/2023-0424-dev-triage-security.markdown
+++ b/_events/2023-0424-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-24T12:00
-tz: UTC -8
+eventdate: 2023-04-24 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-04-24
 online: true
 signup:

--- a/_events/2023-0424-haystack-us-2023.markdown
+++ b/_events/2023-0424-haystack-us-2023.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-04-24T09:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -5
+eventdate: 2023-04-24 09:00:00 -0500
 # the title - this is how it will show up in listing and headings on the site:
 title: Haystack US 2023 - The Search Relevance Conference
 # if your event has an online component, put it here:

--- a/_events/2023-0425.markdown
+++ b/_events/2023-0425.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-25T15:00
-tz: UTC -8
+eventdate: 2023-04-25 15:00:00 -0800
 title: OpenSearch Community Meeting - 2023-04-25
 online: true
 signup:

--- a/_events/2023-0426-rta-sumit.markdown
+++ b/_events/2023-0426-rta-sumit.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-04-26T13:30
-tz: UTC-8
+eventdate: 2023-04-26 13:30:00 -0800
 title: Upgrading Log-Analytics Clusters to OpenSearch
 online: false
 signup:

--- a/_events/2023-0426-rta-sumit.markdown
+++ b/_events/2023-0426-rta-sumit.markdown
@@ -3,6 +3,7 @@
 eventdate: 2023-04-26 13:30:00 -0800
 title: Upgrading Log-Analytics Clusters to OpenSearch
 online: false
+tz: America/Los_Angeles
 signup:
     url: https://www.myeventi.events/rtasummit23/attendee/?code=Stern30
     title: Join RTA-Summit 2023 conference in San Francisco, CA

--- a/_events/2023-0501-dev-triage-security.markdown
+++ b/_events/2023-0501-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-01T12:00
-tz: UTC -8
+eventdate: 2023-05-01 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-05-01
 online: true
 signup:

--- a/_events/2023-0504-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0504-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-04T08:00
-tz: UTC -8
+eventdate: 2023-05-04 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0504
 online: true
 signup:

--- a/_events/2023-0504-dev-officehours-dashboards.markdown
+++ b/_events/2023-0504-dev-officehours-dashboards.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-05-04T10:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
+eventdate: 2023-05-04 10:00:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-05-04
 # if your event has an online component, put it here:

--- a/_events/2023-0508-dev-triage-security.markdown
+++ b/_events/2023-0508-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-08T12:00
-tz: UTC -8
+eventdate: 2023-05-08 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-05-08
 online: true
 signup:

--- a/_events/2023-0510-devoxxuk.markdown
+++ b/_events/2023-0510-devoxxuk.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-05-10 - 2023-05-12
+eventdate: 2023-05-10T08:00:00
 tz: UTC
 title: Using Apache Kafka and OpenSearch to explore Mastodon
 online: false

--- a/_events/2023-0510-devoxxuk.markdown
+++ b/_events/2023-0510-devoxxuk.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-10T08:00:00
-tz: UTC
+eventdate: 2023-05-10 08:00:00 +0000
 title: Using Apache Kafka and OpenSearch to explore Mastodon
 online: false
 signup:

--- a/_events/2023-0510-devoxxuk.markdown
+++ b/_events/2023-0510-devoxxuk.markdown
@@ -3,6 +3,7 @@
 eventdate: 2023-05-10 08:00:00 +0000
 title: Using Apache Kafka and OpenSearch to explore Mastodon
 online: false
+tz: Europe/London
 signup:
     url: https://www.devoxx.co.uk/
     title: Join Devoxx UK 2023 conference in London

--- a/_events/2023-0510-open-source-summit.markdown
+++ b/_events/2023-0510-open-source-summit.markdown
@@ -3,6 +3,7 @@
 eventdate: 2023-05-10 14:00:00 -0800
 title: Demystifying Anomaly Detection in OpenSearch - Open Source Summit North America 2023
 online: false
+tz: America/Vancouver
 signup:
     url: https://ossna2023.sched.com/event/4a16eb089ae3231cf5c2bb76e087b6fb
     title: See you there!

--- a/_events/2023-0510-open-source-summit.markdown
+++ b/_events/2023-0510-open-source-summit.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-10T14:00
-tz: UTC -8
+eventdate: 2023-05-10 14:00:00 -0800
 title: Demystifying Anomaly Detection in OpenSearch - Open Source Summit North America 2023
 online: false
 signup:

--- a/_events/2023-0511-open-source-summit.markdown
+++ b/_events/2023-0511-open-source-summit.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-11T10:00
-tz: UTC -8
+eventdate: 2023-05-11 10:00:00 -0800
 title: Keynote - One Tool, Five Minutes, Countless Applications - Open Source Summit North America 2023
 online: false
 signup:

--- a/_events/2023-0511-open-source-summit.markdown
+++ b/_events/2023-0511-open-source-summit.markdown
@@ -3,6 +3,7 @@
 eventdate: 2023-05-11 10:00:00 -0800
 title: Keynote - One Tool, Five Minutes, Countless Applications - Open Source Summit North America 2023
 online: false
+tz: America/Vancouver
 signup:
     url: https://ossna2023.sched.com/event/1Krni
     title: See you there!

--- a/_events/2023-0515-dev-triage-security.markdown
+++ b/_events/2023-0515-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-15T12:00
-tz: UTC -8
+eventdate: 2023-05-15 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-05-15
 online: true
 signup:

--- a/_events/2023-0518-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0518-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-18T08:00
-tz: UTC -8
+eventdate: 2023-05-18 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0518
 online: true
 signup:

--- a/_events/2023-0518-dev-officehours-dashboards.markdown
+++ b/_events/2023-0518-dev-officehours-dashboards.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-05-18T10:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
+eventdate: 2023-05-18 10:00:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-05-18
 # if your event has an online component, put it here:

--- a/_events/2023-0522-dev-triage-security.markdown
+++ b/_events/2023-0522-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-22T12:00
-tz: UTC -8
+eventdate: 2023-05-22 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-05-22
 online: true
 signup:

--- a/_events/2023-0523.markdown
+++ b/_events/2023-0523.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-23T15:00
-tz: UTC -7
+eventdate: 2023-05-23 15:00:00 -0700
 title: OpenSearch Community Meeting - 2023-05-23
 online: true
 signup:

--- a/_events/2023-0529-dev-triage-security.markdown
+++ b/_events/2023-0529-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-05-29T12:00
-tz: UTC -8
+eventdate: 2023-05-29 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-05-29
 online: true
 signup:

--- a/_events/2023-0601-dev-officehours-dashboards.markdown
+++ b/_events/2023-0601-dev-officehours-dashboards.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-06-01T10:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
+eventdate: 2023-06-01 10:00:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-06-01
 # if your event has an online component, put it here:

--- a/_events/2023-0605-dev-triage-security.markdown
+++ b/_events/2023-0605-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-05T12:00
-tz: UTC -8
+eventdate: 2023-06-05 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-06-05
 online: true
 signup:

--- a/_events/2023-0606.markdown
+++ b/_events/2023-0606.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-06T08:00
-tz: UTC -8
+eventdate: 2023-06-06 08:00:00 -0800
 title: OpenSearch Community Meeting - 2023-06-06
 online: true
 signup:

--- a/_events/2023-0607-chicago-search-meetup.markdown
+++ b/_events/2023-0607-chicago-search-meetup.markdown
@@ -3,6 +3,7 @@
 eventdate: 2023-06-07 18:30:00 -0500
 title: Chicago Search Meetup Launch Event with Bonsai, OpenSearch, and Spantree
 online: false
+tz: America/Chicago
 signup:
     url: https://www.meetup.com/opensearch-project-chicago/events/293331344
     title: RSVP on Meetup

--- a/_events/2023-0607-chicago-search-meetup.markdown
+++ b/_events/2023-0607-chicago-search-meetup.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-07T18:30
-tz: UTC -5
+eventdate: 2023-06-07 18:30:00 -0500
 title: Chicago Search Meetup Launch Event with Bonsai, OpenSearch, and Spantree
 online: false
 signup:

--- a/_events/2023-0612-dev-triage-security.markdown
+++ b/_events/2023-0612-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-12T12:00
-tz: UTC -8
+eventdate: 2023-06-12 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-06-12
 online: true
 signup:

--- a/_events/2023-0615-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0615-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-15T08:00
-tz: UTC -8
+eventdate: 2023-06-15 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0615
 online: true
 signup:

--- a/_events/2023-0615-dev-officehours-dashboards.markdown
+++ b/_events/2023-0615-dev-officehours-dashboards.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-06-15T10:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
+eventdate: 2023-06-15 10:00:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-06-15
 # if your event has an online component, put it here:

--- a/_events/2023-0619-dev-triage-security.markdown
+++ b/_events/2023-0619-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-19T12:00
-tz: UTC -8
+eventdate: 2023-06-19 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-06-19
 online: true
 signup:

--- a/_events/2023-0620.markdown
+++ b/_events/2023-0620.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-20T15:00
-tz: UTC -8
+eventdate: 2023-06-20 15:00:00 -0800
 title: OpenSearch Community Meeting - 2023-06-20
 online: true
 signup:

--- a/_events/2023-0626-dev-triage-security.markdown
+++ b/_events/2023-0626-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-26T12:00
-tz: UTC -8
+eventdate: 2023-06-26 12:00:00 -0800
 title: Development Backlog & Triage Meeting - Security - 2023-06-26
 online: true
 signup:

--- a/_events/2023-0629-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0629-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-06-29T08:00
-tz: UTC -8
+eventdate: 2023-06-29 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0629
 online: true
 signup:

--- a/_events/2023-0713-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0713-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-07-13T08:00
-tz: UTC -8
+eventdate: 2023-07-13 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0713
 online: true
 signup:

--- a/_events/2023-0727-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0727-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
-eventdate: 2023-07-27T08:00
-tz: UTC -8
+eventdate: 2023-07-27 08:00:00 -0800
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0727
 online: true
 signup:

--- a/_events/_0000-0000-communitymeeting-template.markdown
+++ b/_events/_0000-0000-communitymeeting-template.markdown
@@ -1,8 +1,7 @@
 ---
 # rename this file to YYYY-MMDD-meeting-name.markdown - this will be the final URL
 # put your event date and time (24 hr) here:
-eventdate: 2023-02-28T15:00
-tz: UTC -8
+eventdate: 2023-02-28 15:00:00 -0800
 title: OpenSearch Community Meeting - 2023-02-28
 online: true
 signup:

--- a/_events/_0000-0000-communitymeeting-template.markdown
+++ b/_events/_0000-0000-communitymeeting-template.markdown
@@ -1,9 +1,11 @@
 ---
 # rename this file to YYYY-MMDD-meeting-name.markdown - this will be the final URL
-# put your event date and time (24 hr) here:
+# put your event date and time (24 hr) here (mind the time-zone and daylight saving time!):
 eventdate: 2023-02-28 15:00:00 -0800
 title: OpenSearch Community Meeting - 2023-02-28
 online: true
+# If the event is online, remove the next line, otherwise uncomment and adjust it:
+# tz: Pacific/Tahiti
 signup:
     url: https://www.meetup.com/opensearch/events/290444926/
     title: Join on Meetup

--- a/_events/_0000-0000-dev-officehours-dashboards.markdown
+++ b/_events/_0000-0000-dev-officehours-dashboards.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-05-05T10:00
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
+eventdate: 2023-05-05 10:00:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - YYYY-MM-DD
 # if your event has an online component, put it here:

--- a/_events/_0000-0000-dev-officehours-dashboards.markdown
+++ b/_events/_0000-0000-dev-officehours-dashboards.markdown
@@ -3,8 +3,10 @@
 eventdate: 2023-05-05 10:00:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - YYYY-MM-DD
-# if your event has an online component, put it here:
+# if your event has an online component, put it here (mind the time-zone and daylight saving time!):
 online: true
+# If the event is online, remove the next line, otherwise uncomment and adjust it:
+# tz: Pacific/Tahiti
 # This is for the sign up button
 signup:
     # the link URL

--- a/_events/_sample.markdown
+++ b/_events/_sample.markdown
@@ -1,8 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2021-01-01T12:34
-# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
+eventdate: 2021-01-01 12:34:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: Your Event Title
 # if your event has an online component, put it here:

--- a/_events/_sample.markdown
+++ b/_events/_sample.markdown
@@ -1,10 +1,12 @@
 ---
-# put your event date and time (24 hr) here:
+# put your event date and time (24 hr) here (mind the time-zone and daylight saving time!):
 eventdate: 2021-01-01 12:34:00 -0700
 # the title - this is how it will show up in listing and headings on the site:
 title: Your Event Title
-# if your event has an online component, put it here:
 online: true
+# If the event is online, remove the next line, otherwise uncomment and adjust it:
+# tz: Pacific/Tahiti
+
 # This is for the sign up button
 signup:
     # the link URL

--- a/_includes/event.html
+++ b/_includes/event.html
@@ -2,7 +2,7 @@
   <a href="{{ event.url }}">{{event.title}}</a>
   <p> {{ event.content | strip_html | truncatewords: 20 }} </p>
   <div class="meta">
-    {{event.eventdate | date_to_string: "ordinal", "US"  }} 
+    <span class="locale-date">{{ event.eventdate | date_to_rfc822 }}</span>
     &middot;
     {% if event.online %} Online {% endif %}
     {% if event.location.city %} {{event.location.city}} {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,7 +40,7 @@
             "mod/version-switcher": extless("{{'assets/js/mod/version-switcher.js' | relative_url }}"),
             "mod/search-key": extless("{{'assets/js/mod/search-key.js' | relative_url }}"),
             "mod/console-tabs": extless("{{'assets/js/mod/console-tabs.js' | relative_url }}"),
-
+            "mod/locale-date": extless("{{'assets/js/mod/locale-date.js' | relative_url }}"),
         }
     };
     </script>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -22,8 +22,7 @@ body_class: events-page
 {% capture content_related %}
 <div role="complementary">
     <p>
-        <strong>Date:</strong>  {{page.eventdate | date: "%a, %b %d, %Y "}} <br />
-        <strong>Time:</strong> {{page.eventdate | date: "%H:%M"}} ({{page.tz}})
+        <strong>Date:</strong> <span class="locale-datetime" data-tz="{{page.tz}}">{{page.eventdate | date_to_rfc822}}</span>
     </p>
     <a href="{{page.signup.url}}" class="cta" target="_blank">{{page.signup.title}}</a>
 </div>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -75,6 +75,10 @@ define(function() {
         mods.push('mod/pr-maker')
     }
 
+    if (hasClass('locale-date') || hasClass('locale-datetime')) {
+        mods.push('mod/locale-date');
+    }
+
     mods.push('/assets/js/mod/select_logic.js');
 
     require(mods);

--- a/assets/js/mod/locale-date.js
+++ b/assets/js/mod/locale-date.js
@@ -1,0 +1,37 @@
+define(['jquery'], function($) {
+    $('.locale-date').each(function() {
+        var date = new Date(this.innerText);
+        this.replaceWith(date.toDateString());
+    });
+
+    $('.locale-datetime').each(function() {
+        var p = this.parentElement;
+        var date = new Date(this.innerText);
+        var local_tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        var event_tz = this.dataset['tz'];
+
+        $('<h3>In your time zone (' + local_tz + ')</h3>').prependTo(p);
+
+        this.replaceWith(date.toLocaleDateString());
+        $('<br />').appendTo(p);
+        $('<strong>Time:<strong>').appendTo(p);
+        p.append(' ');
+        p.append(date.toLocaleTimeString());
+
+        /*
+         * On-site events have a time zone. If the user time zone is different
+         * than the event one, also display the date and time of the event from
+         * the event timme zone.
+         */
+        if (event_tz && event_tz != local_tz) {
+            $('<h3>In the event time zone (' + event_tz + ')</h3>').appendTo(p);
+            $('<strong>Date:<strong> ').appendTo(p);
+            p.append(' ');
+            p.append(date.toLocaleDateString(undefined, {timeZone: event_tz}));
+            $('<br />').appendTo(p);
+            $('<strong>Time:<strong>').appendTo(p);
+            p.append(' ');
+            p.append(date.toLocaleTimeString(undefined, {timeZone: event_tz}));
+        }
+    });
+});

--- a/events/index.html
+++ b/events/index.html
@@ -6,8 +6,8 @@ body_class: events-page
 notice: true
 ---
 
-{% assign now =  site.time |  date_to_xmlschema %}
-{% assign future_events = site.events | where_exp: "event","event.eventdate  > now" %}
+{% assign now = site.time %}
+{% assign future_events = site.events | where_exp: "event","event.eventdate > now" %}
 {% assign primary_title = site.headings.events %}
 {% assign layout_class = 'sidebar-right events-page' %}
 

--- a/events/past.html
+++ b/events/past.html
@@ -5,8 +5,8 @@ primary_title: Events
 body_class: events-page
 ---
 
-{% assign now =  site.time |  date_to_xmlschema %}
-{% assign past_events = site.events | where_exp: "event","event.eventdate  < now" %}
+{% assign now = site.time %}
+{% assign past_events = site.events | where_exp: "event","event.eventdate < now" %}
 {% assign primary_title = site.headings.events %}
 {% assign layout_class = 'sidebar-right events-page' %}
 


### PR DESCRIPTION
This is a follow-up to #1616.

Use progressive enhancement to show the user the date and time of events in their time zone:

![image](https://github.com/opensearch-project/project-website/assets/148721/29775b1a-6922-4f28-badf-ef722ef85325)


For on-site events, if the user is located in a "foreign" time zone, display both the date and time of the event in the local time zone of the user and the local time zone of the event:

![image](https://github.com/opensearch-project/project-website/assets/148721/a6893580-1bec-457f-8630-ba554860641b)

			     
If JavaScript is disabled, a single timestamp in RFC822 format is displayed.

Screenshots are from a browser on a system configured to speak French.