### PR TITLE
Add OpenSearch Dashboards office hours events Jul - Sep 2023

### DIFF
--- a/_events/2023-0713-dev-officehours-dashboards.markdown
+++ b/_events/2023-0713-dev-officehours-dashboards.markdown
@@ -10,7 +10,7 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url: https://www.meetup.com/opensearch/events/293312244/
+    url: https://www.meetup.com/opensearch/events/294620361/
     # the button text
     title: Join on Meetup
 

--- a/_events/2023-0713-dev-officehours-dashboards.markdown
+++ b/_events/2023-0713-dev-officehours-dashboards.markdown
@@ -1,0 +1,34 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-07-13T10:00
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+tz: UTC -7
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-07-13
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/opensearch/events/293312244/
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-07-13/14910) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-0723-dev-officehours-dashboards.markdown
+++ b/_events/2023-0723-dev-officehours-dashboards.markdown
@@ -1,0 +1,34 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-07-27T10:00
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+tz: UTC -7
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-07-27
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/opensearch/events/293312244/
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-07-27/14911) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-0727-dev-officehours-dashboards.markdown
+++ b/_events/2023-0727-dev-officehours-dashboards.markdown
@@ -10,7 +10,7 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url: https://www.meetup.com/opensearch/events/293312244/
+    url: https://www.meetup.com/opensearch/events/294620387/
     # the button text
     title: Join on Meetup
 

--- a/_events/2023-0810-dev-officehours-dashboards.markdown
+++ b/_events/2023-0810-dev-officehours-dashboards.markdown
@@ -10,7 +10,7 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url: https://www.meetup.com/opensearch/events/293312244/
+    url: https://www.meetup.com/opensearch/events/294620396/
     # the button text
     title: Join on Meetup
 

--- a/_events/2023-0810-dev-officehours-dashboards.markdown
+++ b/_events/2023-0810-dev-officehours-dashboards.markdown
@@ -1,0 +1,34 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-08-10T10:00
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+tz: UTC -7
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-08-10
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/opensearch/events/293312244/
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-08-10/14912) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-0824-dev-officehours-dashboards.markdown
+++ b/_events/2023-0824-dev-officehours-dashboards.markdown
@@ -1,0 +1,34 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-08-24T10:00
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+tz: UTC -7
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-08-24
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/opensearch/events/293312244/
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-08-24/14913) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-0824-dev-officehours-dashboards.markdown
+++ b/_events/2023-0824-dev-officehours-dashboards.markdown
@@ -10,7 +10,7 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url: https://www.meetup.com/opensearch/events/293312244/
+    url: https://www.meetup.com/opensearch/events/294620410/
     # the button text
     title: Join on Meetup
 

--- a/_events/2023-0907-dev-officehours-dashboards.markdown
+++ b/_events/2023-0907-dev-officehours-dashboards.markdown
@@ -10,7 +10,7 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url: https://www.meetup.com/opensearch/events/293312244/
+    url: https://www.meetup.com/opensearch/events/294620421/
     # the button text
     title: Join on Meetup
 

--- a/_events/2023-0907-dev-officehours-dashboards.markdown
+++ b/_events/2023-0907-dev-officehours-dashboards.markdown
@@ -1,0 +1,34 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-09-07T10:00
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+tz: UTC -7
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-09-07
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/opensearch/events/293312244/
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-09-07/14914) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-0921-dev-officehours-dashboards.markdown
+++ b/_events/2023-0921-dev-officehours-dashboards.markdown
@@ -10,7 +10,7 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url: https://www.meetup.com/opensearch/events/293312244/
+    url: https://www.meetup.com/opensearch/events/294620430/
     # the button text
     title: Join on Meetup
 

--- a/_events/2023-0921-dev-officehours-dashboards.markdown
+++ b/_events/2023-0921-dev-officehours-dashboards.markdown
@@ -1,0 +1,34 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-09-21T10:00
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+tz: UTC -7
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-09-21
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/opensearch/events/293312244/
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-09-21/14915) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*


### PR DESCRIPTION
### Description
Add event pages for the next 6 meetings of the OpenSearch Dashboards Office Hours

Meetup links will need to be updated once meetup events are created. Forum posts are currently in the draft topic.
 
### Issues Resolved

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
