### PR TITLE
Pre commit hook fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,14 +10,7 @@ repos:
   hooks:
     - id: malformed-event-dates
       name: Malformed event date check
-      entry: |
-        bash -c\
-        `malformed_event_dates=$(grep -Er --files-without-match '^eventdate: [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [-+][0-9]{4}$' _events)\
-        if [ -n "${malformed_event_dates}" ]; then\
-        echo "Malformed event date in:" >&2\
-        echo "${malformed_event_dates}" >&2\
-        exit 1
-        fi'
+      entry: ./_scripts/_malformeddates.sh
       language: system
       types: [file]
       files: \.(markdown|md)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,6 @@ repos:
         exit 1
         fi'
       language: system
-      types: [python]
+      types: [file]
+      files: \.(markdown|md)$
       pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,19 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+
+- repo: local
+  hooks:
+    - id: malformed-event-dates
+      name: Malformed event date check
+      entry: |
+        bash -c\
+        `malformed_event_dates=$(grep -Er --files-without-match '^eventdate: [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [-+][0-9]{4}$' _events)\
+        if [ -n "${malformed_event_dates}" ]; then\
+        echo "Malformed event date in:" >&2\
+        echo "${malformed_event_dates}" >&2\
+        exit 1
+        fi'
+      language: system
+      types: [python]
+      pass_filenames: false

--- a/_scripts/_malformeddates.sh
+++ b/_scripts/_malformeddates.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-malformed_event_dates=$(grep -Er --files-without-match '^eventdate: [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [-+][0-9]{4}$' _events)\
+malformed_event_dates=$(grep -Er --files-without-match '^eventdate: [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [-+][0-9]{4}$' _events)
 if [ -n "${malformed_event_dates}" ]; then
 echo "Malformed event date in:" >&2
 echo "${malformed_event_dates}" >&2

--- a/_scripts/_malformeddates.sh
+++ b/_scripts/_malformeddates.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+malformed_event_dates=$(grep -Er --files-without-match '^eventdate: [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [-+][0-9]{4}$' _events)\
+if [ -n "${malformed_event_dates}" ]; then
+echo "Malformed event date in:" >&2
+echo "${malformed_event_dates}" >&2
+exit 1
+fi


### PR DESCRIPTION
### Description
Fixing the shell script that fails the events pre-commit hook. 
Adds local linting using #1674

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
