### PR TITLE
Remove time-zone information for online events

### DIFF
--- a/_events/2023-0718-2-9-release-meetings.markdown
+++ b/_events/2023-0718-2-9-release-meetings.markdown
@@ -2,7 +2,6 @@
 
 
 eventdate: 2023-07-19 15:00:00 -0800
-tz: UTC -8
 title: OpenSearch 2.9.0 Release Meetings - 2023-07-18
 online: true
 signup:

--- a/_events/2023-0724-dev-triage-security.markdown
+++ b/_events/2023-0724-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-07-24 12:00:00 -0800
-tz: UTC -8
 title: Development Backlog & Triage Meeting - Security - 2023-07-24
 online: true
 signup:

--- a/_events/2023-0725-efficient-vector-search-opensearch.markdown
+++ b/_events/2023-0725-efficient-vector-search-opensearch.markdown
@@ -2,7 +2,6 @@
 # put your event date and time (24 hr) here:
 eventdate: 2023-07-25 10:00:00 -0700
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
 # the title - this is how it will show up in listing and headings on the site:
 title: Efficient Vector Search with OpenSearch - Webinar with BigData Boutique and MyPart
 # if your event has an online component, put it here:

--- a/_events/2023-0725.markdown
+++ b/_events/2023-0725.markdown
@@ -2,7 +2,6 @@
 
 
 eventdate: 2023-07-25 15:00:00 -0800
-tz: UTC -8
 
 title: OpenSearch Community Meeting - 2023-07-25
 online: true

--- a/_events/2023-0726-search-relevance-triage-backlog.markdown
+++ b/_events/2023-0726-search-relevance-triage-backlog.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-07-26 09:00:00 -0800
-tz: UTC -8
 
 title: Search Relevance - Triage & Backlog Review - 2023-07-26
 online: true

--- a/_events/2023-0727-dev-integrations-apache-spark.markdown
+++ b/_events/2023-0727-dev-integrations-apache-spark.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-07-27 08:00:00 -0800
-tz: UTC -8
 
 title: Planning for Simple Schema Based Integrations and Apache Spark - 2023-0727
 online: true

--- a/_events/2023-0727-dev-officehours-dashboards.markdown
+++ b/_events/2023-0727-dev-officehours-dashboards.markdown
@@ -2,7 +2,6 @@
 # put your event date and time (24 hr) here:
 eventdate: 2023-07-27 10:00:00 -0700
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
 
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-07-27

--- a/_events/2023-0728-generative-ai-brainstorm.markdown
+++ b/_events/2023-0728-generative-ai-brainstorm.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-07-28 09:00:00 -0800
-tz: UTC -8
 
 title: Brainstorm about OpenSearch and generative AI
 online: true

--- a/_events/2023-0731-dev-triage-security.markdown
+++ b/_events/2023-0731-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-07-31 12:00:00 -0800
-tz: UTC -8
 
 title: Development Backlog & Triage Meeting - Security - 2023-07-31
 online: true

--- a/_events/2023-0807-dev-triage-security.markdown
+++ b/_events/2023-0807-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-08-07 12:00:00 -0800
-tz: UTC -8
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-07
 online: true

--- a/_events/2023-0808.markdown
+++ b/_events/2023-0808.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-08-08 08:00:00 -0800
-tz: UTC -8
 
 title: OpenSearch Community Meeting - 2023-08-08
 online: true

--- a/_events/2023-0809-search-relevance-triage-backlog.markdown
+++ b/_events/2023-0809-search-relevance-triage-backlog.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-08-09 09:00:00 -0800
-tz: UTC -8
 
 title: Search Relevance - Triage & Backlog Review - 2023-08-09
 online: true

--- a/_events/2023-0810-dev-officehours-dashboards.markdown
+++ b/_events/2023-0810-dev-officehours-dashboards.markdown
@@ -2,7 +2,6 @@
 # put your event date and time (24 hr) here:
 eventdate: 2023-08-10 10:00:00 -0700
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
 
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-08-10

--- a/_events/2023-0814-dev-triage-security.markdown
+++ b/_events/2023-0814-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-08-14 12:00:00 -0800
-tz: UTC -8
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-14
 online: true

--- a/_events/2023-0821-dev-triage-security.markdown
+++ b/_events/2023-0821-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-08-21 12:00:00 -0800
-tz: UTC -8
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-21
 online: true

--- a/_events/2023-0822.markdown
+++ b/_events/2023-0822.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-08-22 15:00:00 -0800
-tz: UTC -8
 
 title: OpenSearch Community Meeting - 2023-08-22
 online: true

--- a/_events/2023-0824-dev-officehours-dashboards.markdown
+++ b/_events/2023-0824-dev-officehours-dashboards.markdown
@@ -2,7 +2,6 @@
 # put your event date and time (24 hr) here:
 eventdate: 2023-08-24 10:00:00 -0700
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
 
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-08-24

--- a/_events/2023-0828-dev-triage-security.markdown
+++ b/_events/2023-0828-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-08-28 12:00:00 -0800
-tz: UTC -8
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-28
 online: true

--- a/_events/2023-0904-dev-triage-security.markdown
+++ b/_events/2023-0904-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-09-04 12:00:00 -0800
-tz: UTC -8
 title: Development Backlog & Triage Meeting - Security - 2023-09-04
 online: true
 signup:

--- a/_events/2023-0907-dev-officehours-dashboards.markdown
+++ b/_events/2023-0907-dev-officehours-dashboards.markdown
@@ -2,7 +2,6 @@
 # put your event date and time (24 hr) here:
 eventdate: 2023-09-07 10:00:00 -0700
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-09-07
 # if your event has an online component, put it here:

--- a/_events/2023-0911-dev-triage-security.markdown
+++ b/_events/2023-0911-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-09-11 12:00:00 -0800
-tz: UTC -8
 title: Development Backlog & Triage Meeting - Security - 2023-09-11
 online: true
 signup:

--- a/_events/2023-0918-dev-triage-security.markdown
+++ b/_events/2023-0918-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-09-18 12:00:00 -0800
-tz: UTC -8
 title: Development Backlog & Triage Meeting - Security - 2023-09-18
 online: true
 signup:

--- a/_events/2023-0921-dev-officehours-dashboards.markdown
+++ b/_events/2023-0921-dev-officehours-dashboards.markdown
@@ -2,7 +2,6 @@
 # put your event date and time (24 hr) here:
 eventdate: 2023-09-21 10:00:00 -0700
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
-tz: UTC -7
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-09-21
 # if your event has an online component, put it here:

--- a/_events/2023-0925-dev-triage-security.markdown
+++ b/_events/2023-0925-dev-triage-security.markdown
@@ -1,7 +1,6 @@
 ---
 
 eventdate: 2023-09-25 12:00:00 -0800
-tz: UTC -8
 title: Development Backlog & Triage Meeting - Security - 2023-09-25
 online: true
 signup:


### PR DESCRIPTION
When an event is online, we show the start date and time in the user time-zone.

When a `tz` is present, the date and time of the event in that local time zone is also shown to the user, but this is only intended to on-side events: it is intended to help the user better plan their trip.

| It currently show confusing information (local build): | With this change, less confusion for an online-event: |
|----|----|
| ![current](https://github.com/opensearch-project/project-website/assets/148721/f00320cc-2e28-4567-aa32-c5c78a0f7216) | ![after](https://github.com/opensearch-project/project-website/assets/148721/2b0862dc-3df2-4d21-8273-6b7adc279845) |
