### PR TITLE
Fix the TZ offset of future events

### DIFF
--- a/_events/2023-0807-dev-triage-security.markdown
+++ b/_events/2023-0807-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-08-07 12:00:00 -0800
+eventdate: 2023-08-07 12:00:00 -0700
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-07
 online: true

--- a/_events/2023-0808.markdown
+++ b/_events/2023-0808.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-08-08 08:00:00 -0800
+eventdate: 2023-08-08 08:00:00 -0700
 
 title: OpenSearch Community Meeting - 2023-08-08
 online: true

--- a/_events/2023-0809-search-relevance-triage-backlog.markdown
+++ b/_events/2023-0809-search-relevance-triage-backlog.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-08-09 09:00:00 -0800
+eventdate: 2023-08-09 09:00:00 -0700
 
 title: Search Relevance - Triage & Backlog Review - 2023-08-09
 online: true

--- a/_events/2023-0814-dev-triage-security.markdown
+++ b/_events/2023-0814-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-08-14 12:00:00 -0800
+eventdate: 2023-08-14 12:00:00 -0700
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-14
 online: true

--- a/_events/2023-0821-dev-triage-security.markdown
+++ b/_events/2023-0821-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-08-21 12:00:00 -0800
+eventdate: 2023-08-21 12:00:00 -0700
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-21
 online: true

--- a/_events/2023-0822.markdown
+++ b/_events/2023-0822.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-08-22 15:00:00 -0800
+eventdate: 2023-08-22 15:00:00 -0700
 
 title: OpenSearch Community Meeting - 2023-08-22
 online: true

--- a/_events/2023-0828-dev-triage-security.markdown
+++ b/_events/2023-0828-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-08-28 12:00:00 -0800
+eventdate: 2023-08-28 12:00:00 -0700
 
 title: Development Backlog & Triage Meeting - Security - 2023-08-28
 online: true

--- a/_events/2023-0904-dev-triage-security.markdown
+++ b/_events/2023-0904-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-09-04 12:00:00 -0800
+eventdate: 2023-09-04 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2023-09-04
 online: true
 signup:

--- a/_events/2023-0911-dev-triage-security.markdown
+++ b/_events/2023-0911-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-09-11 12:00:00 -0800
+eventdate: 2023-09-11 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2023-09-11
 online: true
 signup:

--- a/_events/2023-0918-dev-triage-security.markdown
+++ b/_events/2023-0918-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-09-18 12:00:00 -0800
+eventdate: 2023-09-18 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2023-09-18
 online: true
 signup:

--- a/_events/2023-0925-dev-triage-security.markdown
+++ b/_events/2023-0925-dev-triage-security.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-09-25 12:00:00 -0800
+eventdate: 2023-09-25 12:00:00 -0700
 title: Development Backlog & Triage Meeting - Security - 2023-09-25
 online: true
 signup:


### PR DESCRIPTION
PT is currently PDT (UTC-7), and not PST (UTC-8).  It looks like the wrong offset was used, inducing a off-by-one error in the displayed times.
