### PR TITLE
Fix event link in the sidebar

### DIFF
--- a/_events/2023-0718-2-9-release-meetings.markdown
+++ b/_events/2023-0718-2-9-release-meetings.markdown
@@ -4,7 +4,7 @@ eventdate: 2023-07-24 11:30:00 -0700
 title: OpenSearch 2.9.0 Release Meetings - 2023-07-24
 online: true
 signup:
-  url: https://www.meetup.com/opensearch/events/tvcvftyfclbcc/
+  url: https://us02web.zoom.us/j/83030994833
   title: Join on Meetup
 
 ---
@@ -39,11 +39,11 @@ Join the OpenSearch team for the open release meetings so we can push 2.9.0 live
 
 * Go / No-Go voting (result = no-go)
 
-**July 19th - 3PM PT**
+**July 19th - 3PM PDT**
 
 * Go / No-Go voting
 
-**July 24th - 11:30AM PT**
+**July 24th - 11:30AM PDT**
 
 * [Release / Post release](https://github.com/opensearch-project/opensearch-build/blob/1499c472fec3d36bc0d3b30ffca8b08bb5a65c4d/RELEASE_PROCESS_OPENSEARCH.md#release) (Release day!) [Release manager, leadership team, Repository owners ]
 


### PR DESCRIPTION
This seems to have been changed by mistake in a464fa34b828bf44cab69ca3912ccbcb80312fdd.

While here, use the PDT time-zone abbreviation rather that PT which is PDT or PST depending on the date.
