### PR TITLE
Remove error highlighting from pygments

### DIFF
--- a/_sass/_pygments.scss
+++ b/_sass/_pygments.scss
@@ -71,10 +71,6 @@ pre.literal-block,
         color: #408080; font-style: italic
     }
     /* Comment */
-    .err {
-        border: 1px solid #FF0000
-    }
-    /* Error */
     .k  {
         color: #008000; font-weight: bold
     }


### PR DESCRIPTION
### Description
Requests/response code uses syntax highlighting when the specified language is `json`. However, in the current pygments style anything that is an error (does not conform to JSON syntax) is highlighted with a red box. Removing the red box will allow to still keep the JSON syntax highlighting.

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
