### PR TITLE
logstash-oss-with-opensearch-output-plugin 8.9.0 download page updates

### DIFF
--- a/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-docker-arm64.markdown
+++ b/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-docker-arm64.markdown
@@ -1,0 +1,21 @@
+---
+role: ingest
+artifact_id: logstash-oss-with-opensearch-output-plugin
+version: 8.9.0
+platform: docker
+architecture: arm64
+slug: logstash-oss-with-opensearch-output-plugin-8.9.0-docker-arm64
+category: logstash-oss-with-opensearch-output-plugin
+type: docker
+inline_instructions:
+- label: "Docker Hub"
+  code: docker pull opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+  link:
+  label: View on Docker Hub
+  url: https://hub.docker.com/r/opensearchproject/logstash-oss-with-opensearch-output-plugin/tags?page=1&ordering=last_updated&name=8.9.0
+- label: "Amazon ECR"
+  code: docker pull public.ecr.aws/opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+  link:
+  label: View on Amazon ECR
+  url: https://gallery.ecr.aws/opensearchproject/logstash-oss-with-opensearch-output-plugin
+---

--- a/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-docker-x64.markdown
+++ b/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-docker-x64.markdown
@@ -1,0 +1,21 @@
+---
+role: ingest
+artifact_id: logstash-oss-with-opensearch-output-plugin
+version: 8.9.0
+platform: docker
+architecture: x64
+slug: logstash-oss-with-opensearch-output-plugin-8.9.0-docker-x64
+category: logstash-oss-with-opensearch-output-plugin
+type: docker
+inline_instructions:
+- label: "Docker Hub"
+  code: docker pull opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+  link:
+  label: View on Docker Hub
+  url: https://hub.docker.com/r/opensearchproject/logstash-oss-with-opensearch-output-plugin/tags?page=1&ordering=last_updated&name=8.9.0
+- label: "Amazon ECR"
+  code: docker pull public.ecr.aws/opensearchproject/logstash-oss-with-opensearch-output-plugin:8.9.0
+  link:
+  label: View on Amazon ECR
+  url: https://gallery.ecr.aws/opensearchproject/logstash-oss-with-opensearch-output-plugin
+---

--- a/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-arm64.markdown
+++ b/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-arm64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: logstash-oss-with-opensearch-output-plugin
+platform: linux
+architecture: arm64
+version: 8.9.0
+artifact_url: https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-arm64.tar.gz
+slug: logstash-oss-with-opensearch-output-plugin-8.9.0-linux-arm64-tar-gz
+category: logstash-oss-with-opensearch-output-plugin
+type: targz
+signature:  https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-arm64.tar.gz.sig
+---

--- a/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-x64.markdown
+++ b/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: logstash-oss-with-opensearch-output-plugin
+platform: linux
+architecture: x64
+version: 8.9.0
+artifact_url: https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-x64.tar.gz
+slug: logstash-oss-with-opensearch-output-plugin-8.9.0-linux-x64-tar-gz
+category: logstash-oss-with-opensearch-output-plugin
+type: targz
+signature: https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.9.0-linux-x64.tar.gz.sig
+---

--- a/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-macos-x64.markdown
+++ b/_artifacts/logstash-oss-with-opensearch-output-plugin/logstash-oss-with-opensearch-output-plugin-8.9.0-macos-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: ingest
+artifact_id: logstash-oss-with-opensearch-output-plugin
+platform: macos
+architecture: x64
+version: 8.9.0
+artifact_url: https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.9.0-macos-x64.tar.gz
+slug: logstash-oss-with-opensearch-output-plugin-8.9.0-macos-x64-tar-gz
+category: logstash-oss-with-opensearch-output-plugin
+type: targz
+signature: https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-8.9.0-macos-x64.tar.gz.sig
+---

--- a/_versions/2021-07-12-opensearch-1.0.0.markdown
+++ b/_versions/2021-07-12-opensearch-1.0.0.markdown
@@ -30,7 +30,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-09-01-opensearch-1.0.1.markdown
+++ b/_versions/2021-09-01-opensearch-1.0.1.markdown
@@ -30,7 +30,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-10-05-opensearch-1.1.0.markdown
+++ b/_versions/2021-10-05-opensearch-1.1.0.markdown
@@ -31,7 +31,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-11-23-opensearch-1.2.0.markdown
+++ b/_versions/2021-11-23-opensearch-1.2.0.markdown
@@ -30,7 +30,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-11-opensearch-1.2.1.markdown
+++ b/_versions/2021-12-11-opensearch-1.2.1.markdown
@@ -30,7 +30,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-16-opensearch-1.2.2.markdown
+++ b/_versions/2021-12-16-opensearch-1.2.2.markdown
@@ -30,7 +30,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2021-12-22-opensearch-1.2.3.markdown
+++ b/_versions/2021-12-22-opensearch-1.2.3.markdown
@@ -30,7 +30,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min

--- a/_versions/2022-01-18-opensearch-1.2.4.markdown
+++ b/_versions/2022-01-18-opensearch-1.2.4.markdown
@@ -24,7 +24,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.2.4

--- a/_versions/2022-03-17-opensearch-1.3.0.markdown
+++ b/_versions/2022-03-17-opensearch-1.3.0.markdown
@@ -24,7 +24,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.0

--- a/_versions/2022-03-30-opensearch-1.3.1.markdown
+++ b/_versions/2022-03-30-opensearch-1.3.1.markdown
@@ -24,7 +24,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.1

--- a/_versions/2022-04-28-opensearch-2.0.0-rc1.markdown
+++ b/_versions/2022-04-28-opensearch-2.0.0-rc1.markdown
@@ -20,7 +20,7 @@ components:
 #    version: 1.1.0
 #  - role: ingest
 #    artifact: logstash-oss-with-opensearch-output-plugin
-#    version: 8.6.1
+#    version: 8.9.0
 #  - role: ingest
 #    artifact: data-prepper
 #    version: data-prepper-1.3.0

--- a/_versions/2022-05-05-opensearch-1.3.2.markdown
+++ b/_versions/2022-05-05-opensearch-1.3.2.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.2

--- a/_versions/2022-05-26-opensearch-2.0.0.markdown
+++ b/_versions/2022-05-26-opensearch-2.0.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.0.0

--- a/_versions/2022-06-09-opensearch-1.3.3.markdown
+++ b/_versions/2022-06-09-opensearch-1.3.3.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.3

--- a/_versions/2022-06-16-opensearch-2.0.1.markdown
+++ b/_versions/2022-06-16-opensearch-2.0.1.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.0.1

--- a/_versions/2022-07-07-opensearch-2.1.0.markdown
+++ b/_versions/2022-07-07-opensearch-2.1.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.1.0

--- a/_versions/2022-07-14-opensearch-1.3.4.markdown
+++ b/_versions/2022-07-14-opensearch-1.3.4.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.4

--- a/_versions/2022-08-11-opensearch-2.2.0.markdown
+++ b/_versions/2022-08-11-opensearch-2.2.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.2.0

--- a/_versions/2022-09-01-opensearch-1.3.5.markdown
+++ b/_versions/2022-09-01-opensearch-1.3.5.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.5

--- a/_versions/2022-09-01-opensearch-2.2.1.markdown
+++ b/_versions/2022-09-01-opensearch-2.2.1.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.2.1

--- a/_versions/2022-09-14-opensearch-2.3.0.markdown
+++ b/_versions/2022-09-14-opensearch-2.3.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.3.0

--- a/_versions/2022-10-06-opensearch-1.3.6.markdown
+++ b/_versions/2022-10-06-opensearch-1.3.6.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.6

--- a/_versions/2022-11-15-opensearch-2.4.0.markdown
+++ b/_versions/2022-11-15-opensearch-2.4.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.4.0

--- a/_versions/2022-12-13-opensearch-1.3.7.markdown
+++ b/_versions/2022-12-13-opensearch-1.3.7.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.7

--- a/_versions/2022-12-13-opensearch-2.4.1.markdown
+++ b/_versions/2022-12-13-opensearch-2.4.1.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.4.1

--- a/_versions/2023-01-24-opensearch-2.5.0.markdown
+++ b/_versions/2023-01-24-opensearch-2.5.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.5.0

--- a/_versions/2023-02-02-opensearch-1.3.8.markdown
+++ b/_versions/2023-02-02-opensearch-1.3.8.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.8

--- a/_versions/2023-02-28-opensearch-2.6.0.markdown
+++ b/_versions/2023-02-28-opensearch-2.6.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.6.0

--- a/_versions/2023-03-16-opensearch-1.3.9.markdown
+++ b/_versions/2023-03-16-opensearch-1.3.9.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.9

--- a/_versions/2023-05-02-opensearch-2.7.0.markdown
+++ b/_versions/2023-05-02-opensearch-2.7.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.7.0

--- a/_versions/2023-05-18-opensearch-1.3.10.markdown
+++ b/_versions/2023-05-18-opensearch-1.3.10.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.10

--- a/_versions/2023-06-06-opensearch-2.8.0.markdown
+++ b/_versions/2023-06-06-opensearch-2.8.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.8.0

--- a/_versions/2023-06-29-opensearch-1.3.11.markdown
+++ b/_versions/2023-06-29-opensearch-1.3.11.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 1.3.11

--- a/_versions/2023-07-24-opensearch-2.9.0.markdown
+++ b/_versions/2023-07-24-opensearch-2.9.0.markdown
@@ -22,7 +22,7 @@ components:
       - linux
   - role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   - role: minimal-artifacts
     artifact: opensearch-min
     version: 2.9.0

--- a/_versions/_2021-12-14-opensearch-1.1.1.markdown
+++ b/_versions/_2021-12-14-opensearch-1.1.1.markdown
@@ -32,7 +32,7 @@ components:
   -
     role: ingest
     artifact: logstash-oss-with-opensearch-output-plugin
-    version: 8.6.1
+    version: 8.9.0
   -
     role: minimal-artifacts
     artifact: opensearch-min


### PR DESCRIPTION
### Description
Adds artifact links for logstash-oss-with-opensearch-output-plugin-8.9.0
 
### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
