### PR TITLE
Conference page mobile device breakpoint corrections

### DIFF
--- a/_sass/_redesign-conference.scss
+++ b/_sass/_redesign-conference.scss
@@ -192,13 +192,13 @@ $content-panel-expand-breakpoint: 834px;
                         height: 175px;
                     }
                 }
-                @media screen and (max-width: 574px) and (min-width: 401px) {
+                @media screen and (max-width: 574px) and (min-width: 428px) {
                     height: 250px;
                     > .speaker-session--speaker-cards--card--content {
                         height: 250px;
                     }
                 }
-                @media screen and (max-width: 400px) {
+                @media screen and (max-width: 427px) {
                     height: 300px;
                     > .speaker-session--speaker-cards--card--content {
                         height: 300px;

--- a/_sass/_redesign-platform.scss
+++ b/_sass/_redesign-platform.scss
@@ -47,6 +47,10 @@
         padding-left: 5px;
         padding-bottom: 20px;
     }
+    @media screen and (max-width: 360px) {
+        padding-left: 0;
+        overflow-x: hidden;
+    }
     background-color: white;
     .platform-page--feature-area {
         display: flex;
@@ -71,6 +75,9 @@
             @media screen and (max-width: 390px) {
                 padding-left: 10px;
                 font-size: 19px;
+            }
+            @media screen and (max-width: 360px) {
+                padding-left: 0;
             }
             color: $secondary-sanfrancisco-fog-s4;
             font-family: 'Open Sans';


### PR DESCRIPTION
### Description
Adds additional breakpoints below 428px to accommodate greater content height for session / speaker cards and prevent the page header / title from extending beyond the width of the page.

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
