### PR TITLE
Session page speaker information patch

### DIFF
--- a/_layouts/speaker_session.html
+++ b/_layouts/speaker_session.html
@@ -27,7 +27,7 @@ feature_area_category_name: Session Summaries
         {%- for speaker in session_speakers -%}
         <div class="speaker-session--speaker-cards--card">
             <div class="speaker-session--speaker-cards--card--image">
-                <img src="{{ speaker.speaker_image }}" alt="{{ page.speaker_name_full }} photograph">
+                <img src="{{ speaker.speaker_image }}" alt="{{ speaker.speaker_name_full }} photograph">
             </div>
             <div class="speaker-session--speaker-cards--card--content">
                 {% if speaker.keynote_speaker %}

--- a/_layouts/speaker_session.html
+++ b/_layouts/speaker_session.html
@@ -27,7 +27,8 @@ feature_area_category_name: Session Summaries
         {%- for speaker in session_speakers -%}
         <div class="speaker-session--speaker-cards--card">
             <div class="speaker-session--speaker-cards--card--image">
-                <img src="{{ speaker.speaker_image }}" alt="{{ speaker.speaker_name_full }} photograph">
+                {% assign speaker_image = speaker.speaker_image | default: "/assets/media/opensearchcon/speakers/no-image-available.png" %}
+                <img src="{{ speaker_image }}" alt="{{ speaker.speaker_name_full }} photograph">
             </div>
             <div class="speaker-session--speaker-cards--card--content">
                 {% if speaker.keynote_speaker %}


### PR DESCRIPTION
### Description
Corrects the speaker image alt text for session page speaker cards (only observable with co-presenters).
Defaults to using the `no-image-available` placeholder image for a speaker card on the session page if the speaker data does not explicitly define one.
 
### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
