### PR TITLE
Add JDBC 1.4.0.1 download link.

### DIFF
--- a/_artifacts/opensearch-drivers/opensearch-jdbc-1.4.0.1.markdown
+++ b/_artifacts/opensearch-drivers/opensearch-jdbc-1.4.0.1.markdown
@@ -1,0 +1,12 @@
+---
+role: driver
+artifact_id: opensearch-sql-jdbc
+version: 1.4.0.1
+platform: java
+architecture: jvm
+artifact_url: https://artifacts.opensearch.org/opensearch-clients/jdbc/opensearch-sql-jdbc-shadow-1.4.0.1.jar
+slug: opensearch-sql-jdbc-1.4.0.1
+category: opensearch
+type: jar
+jarsigner: true
+---

--- a/_versions/2023-07-24-opensearch-2.9.0.markdown
+++ b/_versions/2023-07-24-opensearch-2.9.0.markdown
@@ -34,7 +34,7 @@ components:
     version: 1.5.0.0
   - role: drivers
     artifact: opensearch-sql-jdbc
-    version: 1.3.0.0
+    version: 1.4.0.1
 sections:
   docker-compose:
     explanation: "downloads/opensearch-docker.markdown"

--- a/_versions/2023-08-10-opensearch-1.3.12.markdown
+++ b/_versions/2023-08-10-opensearch-1.3.12.markdown
@@ -34,7 +34,7 @@ components:
     version: 1.1.0.1
   - role: drivers
     artifact: opensearch-sql-jdbc
-    version: 1.1.0.1
+    version: 1.4.0.1
 sections:
   docker-compose:
     explanation: "downloads/opensearch-docker.markdown"


### PR DESCRIPTION
### Description
JDBC driver was [released](https://github.com/opensearch-project/sql-jdbc/releases/tag/1.4.0.1) recently. It was published on maven and on artifacts. This PR adds a link to download the latest release.
 
### Issues Resolved
Add JDBC driver 1.4.0.1 download link.
Closes #1920

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
