### PR TITLE
Removes unused font weights for Open Sans Condensed

### DIFF
--- a/_sass/_web-fonts.scss
+++ b/_sass/_web-fonts.scss
@@ -1,1 +1,1 @@
-@import url('https://fonts.googleapis.com/css2?family=Fira+Mono&family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&family=Open+Sans+Condensed:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,700&family=Open+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Mono&family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&family=Open+Sans+Condensed:ital,wght@0,700&family=Open+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,700&display=swap');


### PR DESCRIPTION
### Description
Removes unnecessary font weights for Open Sans Condensed.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
