### PR TITLE
Removes the vector database callout card header

### DIFF
--- a/_layouts/platform-solution.html
+++ b/_layouts/platform-solution.html
@@ -40,7 +40,7 @@ layout: default
                                 {{ content }}
                             </div>
                             <div class="landing-page-content__right-panel--content--side-panel landing-page-content__right-panel--content--side-panel__has-card-grid">
-                                {% include callout-cards.html callouts=page.callouts heading="Use the vector database functionality built into OpenSearch to:" %}
+                                {% include callout-cards.html callouts=page.callouts %}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Description
Removes the vector database page callout card header text from the side panel.

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
