### PR TITLE
Corrects company name for conference speaker

### DIFF
--- a/_speakers/nschwartz.md
+++ b/_speakers/nschwartz.md
@@ -4,7 +4,7 @@ speaker_image: '/assets/media/opensearchcon/speakers/nschwartz.jpg'
 speaker_name_full: 'Noam Schwartz'
 primary_title: 'Speaker: Noam Schwartz'
 title: 'OpenSearchCon 2023 Speaker: Noam Schwartz'
-speaker_title_and_company: 'Software Engineer at Searchium.ai'
+speaker_title_and_company: 'Software Engineer at GSI Technology / Searchium.ai'
 keynote_speaker: false
 speaker_github: "https://github.com/noamschwartz"
 speaker_linkedin: "https://www.linkedin.com/in/noam-schwartz-ba5466185/"


### PR DESCRIPTION
### Description
Adds the parent company name, GSI Technology, to the speaker bio for Noam Schwartz.
 
### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
