### PR TITLE
Scopes new styles for session schedule to prevent global class clash

### DIFF
--- a/_sass/_redesign-conference.scss
+++ b/_sass/_redesign-conference.scss
@@ -728,65 +728,65 @@ h2.conference-speaker-session-page {
         padding-bottom: 10px;
     }
     grid-template-columns: 1fr;
-}
-
-.schedule-table {
-    background: #FFF;
-    box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.25);
-    border: 12px solid white;
-    border-collapse: separate;
-    display: table;
-    > thead {
-        > tr {
-            > th {
-                border-bottom: 12px solid white;
-                color: $primary-open-sky-s2;
+    .schedule-table {
+        background: #FFF;
+        box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.25);
+        border: 12px solid white;
+        border-collapse: separate;
+        display: table;
+        > thead {
+            > tr {
+                > th {
+                    border-bottom: 12px solid white;
+                    color: $primary-open-sky-s2;
+                }
+            }
+        }
+    
+        > tbody {
+            > tr {
+                > td {
+                    padding: 12px 16px;
+                    border-bottom: 12px solid white;
+                }
+                > td:nth-of-type(1) {
+                    white-space: nowrap;
+                }
+                > td:nth-of-type(n+1) {
+                    @include header-level5($secondary-sanfrancisco-fog-s5);
+                }
+                > td.operating {
+                    background: $secondary-golden-poppy-t3;
+                }
+                > td.search {
+                    background: $primary-deep-blue-sea-t3;
+                }
+                > td.community {
+                    background: $primary-open-sky-t3;
+                }
+                > td.analytics {
+                    background: $secondary-purple-sage-t3;
+                }
             }
         }
     }
-
-    > tbody {
-        > tr {
-            > td {
-                padding: 12px 16px;
-                border-bottom: 12px solid white;
-            }
-            > td:nth-of-type(1) {
-                white-space: nowrap;
-            }
-            > td:nth-of-type(n+1) {
-                @include header-level5($secondary-sanfrancisco-fog-s5);
-            }
-            > td.operating {
-                background: $secondary-golden-poppy-t3;
-            }
-            > td.search {
-                background: $primary-deep-blue-sea-t3;
-            }
-            > td.community {
-                background: $primary-open-sky-t3;
-            }
-            > td.analytics {
-                background: $secondary-purple-sage-t3;
-            }
+    
+    .card {
+        background-color: white;
+        padding:  30px 28px 54px 33px;
+        @include thick-edge-left;
+        @include card-shadow;
+    }
+    
+    a {
+        text-decoration: none;
+        color: $primary-open-sky-s2;
+        &:visited {
+            color: $secondary-sanfrancisco-fog-s4;
         }
-    }
+        &:hover {
+            text-decoration: underline;
+        }
+    }    
 }
 
-.card {
-    background-color: white;
-    padding:  30px 28px 54px 33px;
-    @include thick-edge-left;
-    @include card-shadow;
-}
-
-a {
-    text-decoration: none;
-    color: $primary-open-sky-s2;
-    &:visited {
-        color: $secondary-sanfrancisco-fog-s4;
-    }
-    &:hover {
-        text-decoration: underline;
-    }
-}


### PR DESCRIPTION
### Description
Scopes new styles for session schedule to prevent global class clash. The specifically observed issue was that the visited link style on the homepage download button had been overridden with new styles for the session schedule table.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
