### PR TITLE
Fix all blog button redirect to wrong url

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -137,7 +137,7 @@ layout: default
                 </div>
                 <div class="resource-grid--more">
                     <div class="link-button">
-                        <a href="/blogs">View All Blog Posts</a>
+                        <a href="/blog">View All Blog Posts</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Description
Fix all blog button redirect to wrong url

The correct link is actually `opensearch.org/blog` not `opensearch.org/blogs`.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
