### PR TITLE
Fix OpenSearchCon 2023 info

### DIFF
--- a/_events/2023-0927-opensearchcon.markdown
+++ b/_events/2023-0927-opensearchcon.markdown
@@ -1,8 +1,13 @@
 ---
 
 eventdate: 2023-09-27 08:00:00 -0700
+enddate: 2023-09-29 20:00:00 -0700
 title: OpenSearchCon - 2023
-online: 
+online: false
+tz: America/Los_Angeles
+location:
+    city: Seattle
+    country: USA
 signup:
     url: https://opensearchcon2023.splashthat.com/
     title: Register to attend

--- a/_events/_sample.markdown
+++ b/_events/_sample.markdown
@@ -1,11 +1,17 @@
 ---
 # put your event date and time (24 hr) here (mind the time-zone and daylight saving time!):
 eventdate: 2021-01-01 12:34:00 -0700
+# If the event last multiple day, also add the end date:
+# enddate: 2021-01-03 20:00:00 -0700
+
 # the title - this is how it will show up in listing and headings on the site:
 title: Your Event Title
 online: true
-# If the event is online, remove the next line, otherwise uncomment and adjust it:
+# If the event is online, remove the next lines, otherwise uncomment and adjust:
 # tz: Pacific/Tahiti
+# location:
+#     city: Papeete
+#     country: French Polynesia
 
 # This is for the sign up button
 signup:

--- a/events/index.html
+++ b/events/index.html
@@ -7,7 +7,7 @@ notice: true
 ---
 
 {% assign now = site.time %}
-{% assign future_events = site.events | where_exp: "event","event.eventdate > now" %}
+{% assign future_events = site.events | where_exp: "event","event.eventdate > now or event.enddate > now" %}
 {% assign primary_title = site.headings.events %}
 {% assign layout_class = 'sidebar-right events-page' %}
 

--- a/events/past.html
+++ b/events/past.html
@@ -6,7 +6,7 @@ body_class: events-page
 ---
 
 {% assign now = site.time %}
-{% assign past_events = site.events | where_exp: "event","event.eventdate < now" %}
+{% assign past_events = site.events | where_exp: "event","event.eventdate < now or event.enddate < now" %}
 {% assign primary_title = site.headings.events %}
 {% assign layout_class = 'sidebar-right events-page' %}
 


### PR DESCRIPTION
The event does not include the location information (city, country, TZ) so the event page lacks a lot of information.

While here, adjust the event logic so that events which started and are not finished at the time of rendering appear both in the future events (because it is what is displayed on the event page and the event is still in progress) and the past events.

Also adjust the event template with actual sample data in comments to make it more obvious for people using it what they need to adjust.

| Before (Currently online) | After |
|--------|-------|
| ![image](https://github.com/opensearch-project/project-website/assets/148721/4832a2cc-1dbf-4da9-b5df-48f46c4f50d2) | ![image](https://github.com/opensearch-project/project-website/assets/148721/534221ef-469e-4488-ad94-548475e881a0) |
| ![image](https://github.com/opensearch-project/project-website/assets/148721/fd518169-2e43-48f3-a602-d86aa0568dae) | ![image](https://github.com/opensearch-project/project-website/assets/148721/883296ee-1d26-40f1-8156-d12701b1c88e) |
