### PR TITLE
Fixing the table headings for hybrid-search blog.

### DIFF
--- a/_posts/2023-09-21-hybrid-search.md
+++ b/_posts/2023-09-21-hybrid-search.md
@@ -373,7 +373,7 @@ We are considering including the following improvements in future versions:
 
 The following table provides further details of the test datasets used for benchmarking. 
 
-|Dataset	|Average query length	|Average query length	|Average query length	|Average query length	|Average query length	|Average query length	|
+|Dataset	|Average query length	|Median query Length	|Average passage length	|Median passage Length	|Number of passages	|Number of test queries	|
 |---	|---	|---	|---	|---	|---	|---	|
 |NFCorpus	|3.29	|2	|22.098	|224	|3633	|323	|
 |Trec-Covid	|10.6	|10	|148.64	|155	|171332	|50	|


### PR DESCRIPTION
### Description
Fixing the table headings for hybrid-search blog.

https://opensearch.org/blog/hybrid-search/#:~:text=The%20following%20table%20provides%20further%20details%20of%20the%20test%20datasets%20used%20for%20benchmarking.

Wrong One

![Screenshot 2023-10-04 at 4 05 56 PM](https://github.com/opensearch-project/project-website/assets/6162415/f52e30a3-648f-47b9-9725-5a1a239f62f1)


Right one
![Screenshot 2023-10-04 at 4 06 31 PM](https://github.com/opensearch-project/project-website/assets/6162415/7e688749-0ec2-45a9-a4aa-d2288dbda765)


### Issues Resolved
NA

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
