### PR TITLE
Fix incorrect author username for Data Prepper 2.5.0 blog

### DIFF
--- a/_posts/2023-10-09-Announcing-Data-Prepper-2.5.0.md
+++ b/_posts/2023-10-09-Announcing-Data-Prepper-2.5.0.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Announcing Data Prepper 2.5.0"
 authors:
-- graytaylor0
+- tylgry
 - oeyh
 date: 2023-10-11 11:30:00 -0500
 categories:


### PR DESCRIPTION
### Description
Incorrectly added my author name as `graytaylor0` instead of `tylgry`, causing my description to not render on the blog post for Data Prepper 2.5.0
 

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
