### PR TITLE
Add Fluent Bit events to calendar

### DIFF
--- a/_events/2023-1019-fluent-community-meetup.markdown
+++ b/_events/2023-1019-fluent-community-meetup.markdown
@@ -1,0 +1,26 @@
+---
+# put your event date and time (24 hr) here (mind the time-zone and daylight saving time!):
+eventdate: 2023-10-19 12:00:00 -0400
+# the title - this is how it will show up in listing and headings on the site:
+title: Fluent Community Meeting
+online: true
+# If the event is online, remove the next line, otherwise uncomment and adjust it:
+# tz: Pacific/Tahiti
+
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/fluent-community-meeting/events/296386218/
+    # the button text
+    title: Join the meetup
+
+# below this tripple dash, describe your event. It should be 1-3 sentences
+---
+
+The Fluent Community meeting is an online meetup centered around the Fluentd and Fluent Bit open source projects that are part of the Cloud Native Computing Foundation (CNCF).
+
+Users who are interested in discussing the projects, communicating with maintainers, or are eager to learn about the technologies should join. We also discuss general observability topics for those who are looking to learn more about the subject.
+
+Our agenda for the meeting is an [open document](https://docs.google.com/document/d/1vJvsn8E0SanLO1R0X3RC1qTw0XQK_7q75sZ8IbWAu-g/edit). If you want to add topics to the agenda please request edit permissions.
+
+

--- a/_events/2023-1026-fluent-bit-v2-webinar.markdown
+++ b/_events/2023-1026-fluent-bit-v2-webinar.markdown
@@ -1,0 +1,29 @@
+---
+# put your event date and time (24 hr) here (mind the time-zone and daylight saving time!):
+eventdate: 2023-10-26 12:00:00 -0400
+# the title - this is how it will show up in listing and headings on the site:
+title: Fluent Bit v2 Webinar
+online: true
+# If the event is online, remove the next line, otherwise uncomment and adjust it:
+# tz: Pacific/Tahiti
+
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://calyptia.com/events/fluent-bit-v2-new-integrations-for-otel-wasm-logs-to-metrics-more
+    # the button text
+    title: Lean more and register
+
+# below this tripple dash, describe your event. It should be 1-3 sentences
+---
+
+Learn about the powerful new features of Fluent Bit v2 in this free webinar hosted by Eduardo Silva, the creator of Fluent Bit.
+
+Some of the features covered will include: 
+
+* Full Open Telemetry support. Use a single Fluent Bit agent for all of your Open Telemetry data
+* Custom plugins using Wasm. 
+* Converting logs to metrics 
+* Hot reloads that allow you to make configuration changes without restarting Fluent Bit
+
+

--- a/_events/2023-1102-fluent-community-meetup.markdown
+++ b/_events/2023-1102-fluent-community-meetup.markdown
@@ -1,0 +1,26 @@
+---
+# put your event date and time (24 hr) here (mind the time-zone and daylight saving time!):
+eventdate: 2023-11-02 12:00:00 -0400
+# the title - this is how it will show up in listing and headings on the site:
+title: Fluent Community Meeting
+online: true
+# If the event is online, remove the next line, otherwise uncomment and adjust it:
+# tz: Pacific/Tahiti
+
+# This is for the sign up button
+signup:
+    # the link URL
+    url: https://www.meetup.com/fluent-community-meeting/events/296386228/
+    # the button text
+    title: Join the meetup
+
+# below this tripple dash, describe your event. It should be 1-3 sentences
+---
+
+The Fluent Community meeting is an online meetup centered around the Fluentd and Fluent Bit open source projects that are part of the Cloud Native Computing Foundation (CNCF).
+
+Users who are interested in discussing the projects, communicating with maintainers, or are eager to learn about the technologies should join. We also discuss general observability topics for those who are looking to learn more about the subject.
+
+Our agenda for the meeting is an [open document](https://docs.google.com/document/d/1vJvsn8E0SanLO1R0X3RC1qTw0XQK_7q75sZ8IbWAu-g/edit). If you want to add topics to the agenda please request edit permissions.
+
+


### PR DESCRIPTION
Added an upcoming webinar and the next two Fluent community meetings.

### Description
Adds upcoming Fluent Bit events to the calendar
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
