### PR TITLE
Next six weeks worth of security backlog and triage meetings.

### DIFF
--- a/_events/2023-1016-dev-triage-security.markdown
+++ b/_events/2023-1016-dev-triage-security.markdown
@@ -1,0 +1,37 @@
+---
+
+eventdate: 2023-10-16 12:00:00 -0700
+title: Development Backlog & Triage Meeting - Security - 2023-10-16
+online: true
+signup:
+    url: https://www.meetup.com/opensearch/events/cwtmhtyfcnbvb/
+    title: Join on Meetup
+
+---
+
+Join the OpenSearch Security team for their next backlog & triage planning meeting.
+
+(hosts: [Dave Lago](https://github.com/davidlago), [Peter Nied](https://github.com/peternied), & [Stephen Crawford](https://github.com/scrawfor99))
+
+**Agenda:**
+
+**Triage issues** *(add the triaged label once reviewed/ready. They can be also labelled as sprint backlog if we are looking to queueing them up next, or good first issue / help wanted when appropriate.)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+
+**Sprint backlog** *(Examine if it still reflects the work that we are committing to doing and is it in the right priority order)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+
+**Backlog** *(anything we should move to sprint backlog? anything we should tag asking for help from the community?)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22)
+
+
+***Please see Meetup link for URL and required passcode.***
+
+
+*By joining the Development Backlog & Triage Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the Development Backlog & Triage Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1023-dev-triage-security.markdown
+++ b/_events/2023-1023-dev-triage-security.markdown
@@ -1,0 +1,37 @@
+---
+
+eventdate: 2023-10-23 12:00:00 -0700
+title: Development Backlog & Triage Meeting - Security - 2023-10-23
+online: true
+signup:
+    url: https://www.meetup.com/opensearch/events/cwtmhtyfcnbvb/
+    title: Join on Meetup
+
+---
+
+Join the OpenSearch Security team for their next backlog & triage planning meeting.
+
+(hosts: [Dave Lago](https://github.com/davidlago), [Peter Nied](https://github.com/peternied), & [Stephen Crawford](https://github.com/scrawfor99))
+
+**Agenda:**
+
+**Triage issues** *(add the triaged label once reviewed/ready. They can be also labelled as sprint backlog if we are looking to queueing them up next, or good first issue / help wanted when appropriate.)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+
+**Sprint backlog** *(Examine if it still reflects the work that we are committing to doing and is it in the right priority order)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+
+**Backlog** *(anything we should move to sprint backlog? anything we should tag asking for help from the community?)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22)
+
+
+***Please see Meetup link for URL and required passcode.***
+
+
+*By joining the Development Backlog & Triage Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the Development Backlog & Triage Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1030-dev-triage-security.markdown
+++ b/_events/2023-1030-dev-triage-security.markdown
@@ -1,0 +1,37 @@
+---
+
+eventdate: 2023-10-30 12:00:00 -0700
+title: Development Backlog & Triage Meeting - Security - 2023-10-30
+online: true
+signup:
+    url: https://www.meetup.com/opensearch/events/cwtmhtyfcnbvb/
+    title: Join on Meetup
+
+---
+
+Join the OpenSearch Security team for their next backlog & triage planning meeting.
+
+(hosts: [Dave Lago](https://github.com/davidlago), [Peter Nied](https://github.com/peternied), & [Stephen Crawford](https://github.com/scrawfor99))
+
+**Agenda:**
+
+**Triage issues** *(add the triaged label once reviewed/ready. They can be also labelled as sprint backlog if we are looking to queueing them up next, or good first issue / help wanted when appropriate.)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+
+**Sprint backlog** *(Examine if it still reflects the work that we are committing to doing and is it in the right priority order)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+
+**Backlog** *(anything we should move to sprint backlog? anything we should tag asking for help from the community?)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22)
+
+
+***Please see Meetup link for URL and required passcode.***
+
+
+*By joining the Development Backlog & Triage Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the Development Backlog & Triage Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1106-dev-triage-security.markdown
+++ b/_events/2023-1106-dev-triage-security.markdown
@@ -1,0 +1,37 @@
+---
+
+eventdate: 2023-11-06 12:00:00 -0700
+title: Development Backlog & Triage Meeting - Security - 2023-11-06
+online: true
+signup:
+    url: https://www.meetup.com/opensearch/events/cwtmhtyfcnbvb/
+    title: Join on Meetup
+
+---
+
+Join the OpenSearch Security team for their next backlog & triage planning meeting.
+
+(hosts: [Dave Lago](https://github.com/davidlago), [Peter Nied](https://github.com/peternied), & [Stephen Crawford](https://github.com/scrawfor99))
+
+**Agenda:**
+
+**Triage issues** *(add the triaged label once reviewed/ready. They can be also labelled as sprint backlog if we are looking to queueing them up next, or good first issue / help wanted when appropriate.)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+
+**Sprint backlog** *(Examine if it still reflects the work that we are committing to doing and is it in the right priority order)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+
+**Backlog** *(anything we should move to sprint backlog? anything we should tag asking for help from the community?)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22)
+
+
+***Please see Meetup link for URL and required passcode.***
+
+
+*By joining the Development Backlog & Triage Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the Development Backlog & Triage Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1113-dev-triage-security.markdown
+++ b/_events/2023-1113-dev-triage-security.markdown
@@ -1,0 +1,37 @@
+---
+
+eventdate: 2023-11-13 12:00:00 -0700
+title: Development Backlog & Triage Meeting - Security - 2023-11-13
+online: true
+signup:
+    url: https://www.meetup.com/opensearch/events/cwtmhtyfcnbvb/
+    title: Join on Meetup
+
+---
+
+Join the OpenSearch Security team for their next backlog & triage planning meeting.
+
+(hosts: [Dave Lago](https://github.com/davidlago), [Peter Nied](https://github.com/peternied), & [Stephen Crawford](https://github.com/scrawfor99))
+
+**Agenda:**
+
+**Triage issues** *(add the triaged label once reviewed/ready. They can be also labelled as sprint backlog if we are looking to queueing them up next, or good first issue / help wanted when appropriate.)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+
+**Sprint backlog** *(Examine if it still reflects the work that we are committing to doing and is it in the right priority order)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+
+**Backlog** *(anything we should move to sprint backlog? anything we should tag asking for help from the community?)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22)
+
+
+***Please see Meetup link for URL and required passcode.***
+
+
+*By joining the Development Backlog & Triage Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the Development Backlog & Triage Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1120-dev-triage-security.markdown
+++ b/_events/2023-1120-dev-triage-security.markdown
@@ -1,0 +1,37 @@
+---
+
+eventdate: 2023-11-20 12:00:00 -0700
+title: Development Backlog & Triage Meeting - Security - 2023-11-20
+online: true
+signup:
+    url: https://www.meetup.com/opensearch/events/cwtmhtyfcnbvb/
+    title: Join on Meetup
+
+---
+
+Join the OpenSearch Security team for their next backlog & triage planning meeting.
+
+(hosts: [Dave Lago](https://github.com/davidlago), [Peter Nied](https://github.com/peternied), & [Stephen Crawford](https://github.com/scrawfor99))
+
+**Agenda:**
+
+**Triage issues** *(add the triaged label once reviewed/ready. They can be also labelled as sprint backlog if we are looking to queueing them up next, or good first issue / help wanted when appropriate.)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3Atriaged+)
+
+**Sprint backlog** *(Examine if it still reflects the work that we are committing to doing and is it in the right priority order)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22+)
+
+**Backlog** *(anything we should move to sprint backlog? anything we should tag asking for help from the community?)*
+
+* [Backend security](https://github.com/opensearch-project/security/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22+)
+* [Dashboards security](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+-label%3A%22sprint+backlog%22+-label%3A%22WIP%22+label%3A%22triaged%22)
+
+
+***Please see Meetup link for URL and required passcode.***
+
+
+*By joining the Development Backlog & Triage Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the Development Backlog & Triage Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*


### PR DESCRIPTION
### Description
We've lagged behind in putting our dev security triage and backlog meetings on the event calendar. Here's the next six weeks worth. 
 
### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
