### PR TITLE
Add OpenSearch Dashboards office hours events Oct - Dec 2023

### DIFF
--- a/_events/2023-1019-dev-officehours-dashboards.markdown
+++ b/_events/2023-1019-dev-officehours-dashboards.markdown
@@ -1,0 +1,33 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-10-19 10:00:00 -0700
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-10-19
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url:
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-10-19/16308) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1102-dev-officehours-dashboards.markdown
+++ b/_events/2023-1102-dev-officehours-dashboards.markdown
@@ -1,0 +1,33 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-11-02 10:00:00 -0700
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-11-02
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url:
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-11-02/16309) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1116-dev-officehours-dashboards.markdown
+++ b/_events/2023-1116-dev-officehours-dashboards.markdown
@@ -1,0 +1,33 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-11-16 10:00:00 -0700
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-11-16
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url:
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-11-16/16310) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1130-dev-officehours-dashboards.markdown
+++ b/_events/2023-1130-dev-officehours-dashboards.markdown
@@ -1,0 +1,33 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-11-30 10:00:00 -0700
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-11-30
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url:
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-11-30/16311) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*

--- a/_events/2023-1214-dev-officehours-dashboards.markdown
+++ b/_events/2023-1214-dev-officehours-dashboards.markdown
@@ -1,0 +1,33 @@
+---
+# put your event date and time (24 hr) here:
+eventdate: 2023-12-14 10:00:00 -0700
+# the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
+# the title - this is how it will show up in listing and headings on the site:
+title: OpenSearch Dashboards Developer Office Hours - 2023-12-14
+# if your event has an online component, put it here:
+online: true
+# This is for the sign up button
+signup:
+    # the link URL
+    url:
+    # the button text
+    title: Join on Meetup
+
+# below this triple dash, describe your event. It should be 1-3 sentences
+---
+
+Join the OpenSearch Dashboards team for developer office hours.
+
+(host: [Josh Romero](https://github.com/joshuarrrr))
+
+**Agenda:**
+
+*Visit the [forum post](https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-12-14/16312) to sign-up and view planned topics.*
+
+The meeting is divided into four 15-minute slots for community developers to chat with [OpenSearch Dashboards project maintainers](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md). Priority will be given to topics that are signed-up in advance, but ad-hoc discussions are welcome in any remaining time. If there are no sign-ups, maintainers will present a brief knowledge-sharing session or demo and the meeting may end early.
+
+***Please see Meetup link for URL and required passcode.***
+
+After the meeting, we will post the chat log and any meeting notes. We welcome you to keep the conversation going on the forum.
+
+*By joining the OpenSearch Community Meeting, you grant OpenSearch, and our affiliates the right to record, film, photograph, and capture your voice and image during the OpenSearch Community Meeting (the “Recordings”). You grant to us an irrevocable, nonexclusive, perpetual, worldwide, royalty-free right and license to use, reproduce, modify, distribute, and translate, for any purpose, all or any part of the Recordings and Your Materials. For example, we may distribute Recordings or snippets of Recordings via our social media outlets.*


### PR DESCRIPTION
### Description

 Add event pages for the next 5 meetings of the OpenSearch Dashboards Office Hours

Meetup links will need to be updated once meetup events are created. Forum posts are currently in the draft topic.

### Issues Resolved

N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
