### PR TITLE
Migrates slack, projects, partners, releases, and faq pages to new te…

### DIFF
--- a/_sass/_fullwidth-with-breadcrumbs.scss
+++ b/_sass/_fullwidth-with-breadcrumbs.scss
@@ -68,7 +68,8 @@
             padding-top: 0;
             margin-bottom: 0;
         }
-        > h5:nth-of-type(1) + ul:nth-of-type(1) {
+        > h5:nth-of-type(1) + ul:nth-of-type(1),
+        .in-page-links-list {
             @include page-element-left-right-margins;
             list-style-type: none;
             padding-left: 0;
@@ -87,7 +88,9 @@
                 padding-top: 0;
             }
         }
-
+        > ul {
+            @include page-element-left-right-margins;
+        }
         > p {
             @include page-paragraph-padding;
             margin: 0;
@@ -98,7 +101,8 @@
                 padding-bottom: 2em;
             }
         }
-        > div {
+        > div,
+        section {
             @include page-element-padding;
         }
         > h2,
@@ -148,67 +152,6 @@
                 }
                 > p {
                     margin-top: 0;
-                }
-            }
-        }
-        > table {
-            @include page-element-margins;
-            > thead {
-                > tr {
-                    > th,
-                    th:nth-of-type(1) {
-                        white-space: normal;
-                        overflow-x: auto;
-                    }
-                }
-            }
-            &:nth-of-type(1) {
-                @extend .basic-data-table;
-                > tbody {
-                    > tr {
-                        > td:nth-of-type(1) {
-                            font-weight: 700;
-                            color: $primary-open-sky-s2;
-                        }
-                    }
-                }
-            }
-            &:nth-of-type(2) {
-                @extend .basic-data-table;
-                > tbody {
-                    > tr {
-                        > td:nth-of-type(1),
-                        > td:nth-of-type(2) {
-                            font-weight: 700;
-                            color: $primary-open-sky-s2;
-                        }
-                    }
-                }
-            }
-            &:nth-of-type(3) {
-                @extend .basic-data-table;
-                width: 50%;
-            }
-            &:nth-of-type(4) {
-                @extend .platform-page--solutions--use-cases--table;    
-                > tbody {
-                    > tr {
-                        > td {
-                            @include header-level5($secondary-sanfrancisco-fog-s5);
-                            // Implementation note: These are overrides to the base use-cases--table styles.
-                            &:nth-of-type(1) {
-                                @include header-level5($secondary-sanfrancisco-fog-s5);
-                            }
-                            &:nth-of-type(2) {
-                                @include header-level5($secondary-sanfrancisco-fog-s5);
-                            }
-                            @media screen and (min-width: 601px) {
-                                &:nth-of-type(1) {
-                                    width: auto;
-                                }
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/_sass/_redesign.scss
+++ b/_sass/_redesign.scss
@@ -515,6 +515,15 @@ $header-banner-mobile-breakpoint: 1018px;
                 }
             }
             > .landing-page-hero--images {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
                 > .landing-page-hero--images--image {
                     &.landing-page-hero--images--image__desktop {
                         > img {

--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -48,6 +48,7 @@
 }
 
 .basic-data-table {
+  @include page-element-margins;
   box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.25);
   > thead {
     > tr {
@@ -76,6 +77,59 @@
         font-weight: 400;
         line-height: 48px;
         padding: 10px 12px;
+      }
+    }
+  }
+}
+
+.data-table__bold-first-column {
+  @extend .basic-data-table;
+  > tbody {
+    > tr {
+      > td:nth-of-type(1) {
+        font-weight: 700;
+        color: $primary-open-sky-s2;
+      }
+    }
+  }
+}
+
+.data-table__bold-first-two-columns {
+  @extend .data-table__bold-first-column;
+  > tbody {
+    > tr {
+      > td:nth-of-type(2) {
+        font-weight: 700;
+        color: $primary-open-sky-s2;
+      }
+    }
+  }
+}
+
+.data-table__half-width {
+  @extend .basic-data-table;
+  width: 50%;
+}
+
+.data-table__use-case-styles {
+  @extend .platform-page--solutions--use-cases--table;
+  @include page-element-margins;
+  > tbody {
+    > tr {
+      > td {
+        @include header-level5($secondary-sanfrancisco-fog-s5);
+        // Implementation note: These are overrides to the base use-cases--table styles.
+        &:nth-of-type(1) {
+          @include header-level5($secondary-sanfrancisco-fog-s5);
+        }
+        &:nth-of-type(2) {
+          @include header-level5($secondary-sanfrancisco-fog-s5);
+        }
+        @media screen and (min-width: 601px) {
+          &:nth-of-type(1) {
+            width: auto;
+          }
+        }
       }
     }
   }

--- a/community_projects/index.html
+++ b/community_projects/index.html
@@ -1,8 +1,13 @@
 ---
-layout: fullwidth
+layout: fullwidth-with-breadcrumbs
 title: Community Projects
 primary_title: Community Projects
 body_class: community_projects-page
+breadcrumbs:
+  icon: community
+  items:
+    - title: Community Projects
+      url: '/community_projects/'
 ---
 
 <p>This page was made to highlight projects built by the community for the community.</p>

--- a/faq/index.html
+++ b/faq/index.html
@@ -1,15 +1,25 @@
 ---
-layout: fullwidth
+layout: fullwidth-with-breadcrumbs
 title: Frequently Asked Questions
-primary_title: FAQ
+primary_title: Frequently Asked Questions
 notice: true
+breadcrumbs:
+  icon: platform
+  items:
+    - title: About
+      url: '/about.html'
+    - title: FAQ
+      url: '/faq/'
 ---
-<h2> {{page.title}} </h2>
+
 {% assign faqs = site.faqs | group_by: 'category' %}
-Categories: {% for faq_group in faqs  %}
-  {% assign categoryindex = forloop.index %}
-  <a href="#c{{categoryindex}}">{{ faq_group.name }}</a>  {% if forloop.last != true %} &middot; {% endif %}
-{% endfor %}
+<ul class="in-page-links-list">
+  <li>Categories:</li>
+  {% for faq_group in faqs  %}
+    {% assign categoryindex = forloop.index %}
+    <li><a href="#c{{categoryindex}}">{{ faq_group.name }}</a></li>
+  {% endfor %}
+</ul>
 
 <ol id="faq">
   

--- a/partners/index.html
+++ b/partners/index.html
@@ -1,9 +1,14 @@
 ---
-layout: fullwidth
+layout: fullwidth-with-breadcrumbs
 title: Partners
 primary_title: Partners
 body_class: partners-page
 notice: true
+breadcrumbs:
+  icon: community
+  items:
+    - title: Partners
+      url: '/partners/'
 ---
 
 <p>OpenSearch is a team effort, we are grateful to all our partners.</p>

--- a/releases.md
+++ b/releases.md
@@ -1,15 +1,20 @@
 ---
-layout: fullwidth
+layout: fullwidth-with-breadcrumbs
 primary_title: Release Schedule and Maintenance Policy
 title: Release Schedule and Maintenance Policy
+breadcrumbs:
+  icon: platform
+  items:
+    - title: About
+      url: '/about.html'
+    - title: Releases
+      url: '/releases.html'
 ---
 
+##### Updated September 11, 2023
 
-_Updated September 11, 2023_
-
-[Release Schedule](#release-schedule) &middot; [Maintenance Policy](#maintenance-policy)
-
----
+* [Release Schedule](#release-schedule)
+* [Maintenance Policy](#maintenance-policy)
 
 ## Release Schedule ##
 
@@ -17,15 +22,15 @@ For more information on the changes planned for each release, please see the [Pr
 
 Note:  We have not added a major release to the 2023 schedule yet.  If/when we add one, it will replace a minor release in the 2.x line.  See below for criteria for a major releases.
 
-<div class="table-styler"></div>
 
-| Release Number| First RC Generated (release window opens) | Latest Possible Release Date (release window closes) | Release Date |
-|:--------------|:-----------------|:---------------|:---------------|
+| Release Number| First RC Generated (release window opens) | Latest Possible Release Date (release window closes) |
+|:--------------|:-----------------|:---------------|
 | 2.10.0        | September 07th   | September 25th |
 | 1.3.13        | September 14th   | September 21st |
 | 2.11.0        | October 4th      | October 18th   |
 | 1.3.14        | December 5th     | December 12th  |
 | 2.12.0        | January 9th, 2024    | January 23rd, 2024  |
+{: .data-table__bold-first-column}
 
 OpenSearch [follows semver](https://opensearch.org/blog/technical-post/2021/08/what-is-semver/), which means we will only release breaking changes in major versions.  All minor versions are compatible with every other minor version for that major.  For example, 1.2.0 will work with 1.3.2, 1.4.1, etc, but may not work with 2.0.
 
@@ -49,18 +54,17 @@ The duration of the maintenance window will vary from product to product and rel
 
 The software maintainers will not back-port fixes or features to versions outside of the maintenance window. That said, PRs with said back-ports are welcome and will follow the project’s [review process](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#review-process). No new releases will result from these changes, but interested parties can [create their own distribution](https://github.com/opensearch-project/opensearch-build#building-and-testing-an-opensearch-distribution) from the updated source after the PRs are merged.
 
-<div class="table-styler"></div>
 
 | Major Version | Latest Minor Version |   Status    | Initial Release | Maintenance Window Start | Maintenance Window End             |
-|:--------------|:---------------------|:-----------:|:---------------:|:------------------------:|:----------------------:            |
-| 1             | 1.3.x                | Maintenance |  July 12, 2021  |       May 26, 2022       |    GA release of 3.0.              |
-| 2             | 2.0.0                |   Current   |  May 26, 2022   |           N/A            |          N/A                       |
+|:--------------|:---------------------|:------------|:----------------|:-------------------------|:-----------------------            |
+| 1             | 1.3.x                | Maintenance |  July 12, 2021  | May 26, 2022             | GA release of 3.0.                 |
+| 2             | 2.0.0                | Current     |  May 26, 2022   | N/A                      | N/A                                |
+{: .data-table__bold-first-two-columns}
 
 *Note that the length of the maintenance window is an estimated minimum and the project may, at its discretion, extend it _to a later_ date
 
 ## Release History ##
 
-<div class="table-styler"></div>
 
 | Release Number |  Release Date      |
 |:---------------|:-------------------|
@@ -82,10 +86,10 @@ The software maintainers will not back-port fixes or features to versions outsid
 | 2.8.0          | May 30th, 2023        |
 | 1.3.11         | June 22nd, 2023       |
 | 2.9.0          | July 11th, 2023       |
+{: .data-table__half-width}
 
 ## Change Log ##
 
-<div class="table-styler"></div>
 
 | Date         | Change | Reason          |
 |:-------------|:-------|:----------------|
@@ -102,5 +106,4 @@ The software maintainers will not back-port fixes or features to versions outsid
 | September 6th, 2023 | Updated 2.10 date  |  8 hour github outage last night - moving to accomodate a few final fixes |
 | September 11th, 2023 | Link to RELEASING.md  |  updated link from proposal to releasing documentation |
 | September 29th, 2023 | Updated 2.11 date | Per discussion [in this issue](https://github.com/opensearch-project/opensearch-build/issues/3955) |
-
-<br>
+{: .data-table__use-case-styles}

--- a/slack.markdown
+++ b/slack.markdown
@@ -1,12 +1,16 @@
 ---
-layout: fullwidth
+layout: fullwidth-with-breadcrumbs
 primary_title: Slack workspace
 title: Slack workspace
+breadcrumbs:
+  icon: community
+  items:
+    - title: 'Community'
+    - title: 'Slack Workspace'
+      url: '/slack.html'
 ---
 
-_Updated Oct 17, 2023_
-
----
+##### Updated Oct 17, 2023
 
 The OpenSearch Project has a public Slack to enable brainstorming, code reviews, and other ad hoc collaboration discussions with the community.
 
@@ -23,6 +27,3 @@ In addition to the [OpenSearch Code of Conduct](https://opensearch.org/codeofcon
 
 Contributors, maintainers, and community members can use this communication channel to collaborate.
 Read more on Slack [communications here](https://github.com/opensearch-project/.github/blob/main/COMMUNICATIONS.md).
-
-
-<br />


### PR DESCRIPTION
### Description
Migrates slack, projects, partners, releases, and faq pages to new template.
Also fixes a problem with hero carousel background image sizing that was mistakenly introduced.

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
