### PR TITLE
Fix date of next community meeting

### DIFF
--- a/_events/2023-1114-community-meeting.markdown
+++ b/_events/2023-1114-community-meeting.markdown
@@ -1,6 +1,6 @@
 ---
 
-eventdate: 2023-11-14 15:00:00 -0700
+eventdate: 2023-11-14 15:00:00 -0800
 
 title: OpenSearch Community Meeting - 2023-11-14
 online: true


### PR DESCRIPTION
In my time zone, the website says "Date: 14/11/2023 Time: 12:00:00", on
meetup, I see "Tuesday, November 14, 2023 at 1:00 PM to Tuesday,
November 14, 2023 at 2:00 PM UTC−10".  Looks-like the TZ offset is not
the good one.
