### PR TITLE
Fix OpenSearch Dashboards Developer Office Hours

### DIFF
--- a/_events/2023-1116-dev-officehours-dashboards.markdown
+++ b/_events/2023-1116-dev-officehours-dashboards.markdown
@@ -1,6 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-11-16 10:00:00 -0700
+eventdate: 2023-11-16 10:00:00 -0800
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-11-16
@@ -9,9 +9,9 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url:
+    url: https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-11-16/16310
     # the button text
-    title: Join on Meetup
+    title: Join on Zoom
 
 # below this triple dash, describe your event. It should be 1-3 sentences
 ---

--- a/_events/2023-1130-dev-officehours-dashboards.markdown
+++ b/_events/2023-1130-dev-officehours-dashboards.markdown
@@ -1,6 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-11-30 10:00:00 -0700
+eventdate: 2023-11-30 10:00:00 -0800
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-11-30
@@ -9,9 +9,9 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url:
+    url: https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-11-30/16311
     # the button text
-    title: Join on Meetup
+    title: Join on Zoom
 
 # below this triple dash, describe your event. It should be 1-3 sentences
 ---

--- a/_events/2023-1214-dev-officehours-dashboards.markdown
+++ b/_events/2023-1214-dev-officehours-dashboards.markdown
@@ -1,6 +1,6 @@
 ---
 # put your event date and time (24 hr) here:
-eventdate: 2023-12-14 10:00:00 -0700
+eventdate: 2023-12-14 10:00:00 -0800
 # the UTC offset (https://en.wikipedia.org/wiki/UTC_offset):
 # the title - this is how it will show up in listing and headings on the site:
 title: OpenSearch Dashboards Developer Office Hours - 2023-12-14
@@ -9,9 +9,9 @@ online: true
 # This is for the sign up button
 signup:
     # the link URL
-    url:
+    url: https://forum.opensearch.org/t/opensearch-dashboards-developer-office-hours-2023-12-14/16312
     # the button text
-    title: Join on Meetup
+    title: Join on Zoom
 
 # below this triple dash, describe your event. It should be 1-3 sentences
 ---


### PR DESCRIPTION
The event was probably using the wrong time-zone information (probably
due to daylight saving that recently changed).  While here, ensure the
join button was functional and fix its label.

The event is passed, but it will hopefuly help if it is taken as a
template to create a new event in the future.

Signed-off-by: Romain Tartière <romain@blogreen.org>
