### PR TITLE
No events status message, events view and link fixes

### DIFF
--- a/_calendars/2024-01.md
+++ b/_calendars/2024-01.md
@@ -3,7 +3,7 @@ layout: calendar
 year: 2024
 month_index: 0
 month_number: 1
-date_of_first_sunday: '2024-12-31'
+date_of_first_sunday: '2023-12-31'
 date_of_last_saturday: '2024-02-03'
 calendar_view_week_count: 5
 title: Events Calendar

--- a/_calendars/2024-01.md
+++ b/_calendars/2024-01.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-12-31'
 date_of_last_saturday: '2024-02-03'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-02.md
+++ b/_calendars/2024-02.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-01-28'
 date_of_last_saturday: '2024-02-02'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-02.md
+++ b/_calendars/2024-02.md
@@ -4,7 +4,7 @@ year: 2024
 month_index: 1
 month_number: 2
 date_of_first_sunday: '2024-01-28'
-date_of_last_saturday: '2024-02-02'
+date_of_last_saturday: '2024-03-02'
 calendar_view_week_count: 5
 title: Events Calendar
 primary_title: Events Calendar

--- a/_calendars/2024-03.md
+++ b/_calendars/2024-03.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-02-25'
 date_of_last_saturday: '2024-04-06'
 calendar_view_week_count: 6
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-04.md
+++ b/_calendars/2024-04.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-03-31'
 date_of_last_saturday: '2024-05-04'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-05.md
+++ b/_calendars/2024-05.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-04-28'
 date_of_last_saturday: '2024-06-01'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-06.md
+++ b/_calendars/2024-06.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-05-26'
 date_of_last_saturday: '2024-07-06'
 calendar_view_week_count: 6
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-07.md
+++ b/_calendars/2024-07.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-06-30'
 date_of_last_saturday: '2024-08-03'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-08.md
+++ b/_calendars/2024-08.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-07-28'
 date_of_last_saturday: '2024-08-31'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-09.md
+++ b/_calendars/2024-09.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-09-01'
 date_of_last_saturday: '2024-10-05'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-10.md
+++ b/_calendars/2024-10.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-09-29'
 date_of_last_saturday: '2024-11-02'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-11.md
+++ b/_calendars/2024-11.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-10-27'
 date_of_last_saturday: '2024-11-30'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_calendars/2024-12.md
+++ b/_calendars/2024-12.md
@@ -7,6 +7,7 @@ date_of_first_sunday: '2024-12-01'
 date_of_last_saturday: '2025-01-04'
 calendar_view_week_count: 5
 title: Events Calendar
+primary_title: Events Calendar
 breadcrumbs:
   icon: community
   items:

--- a/_data/top_nav.yml
+++ b/_data/top_nav.yml
@@ -76,6 +76,7 @@ items:
       -
         label: Events
         url: /events
+        class_name: 'events-page-menu-link__device-based'
       -
         label: Partners
         url: /partners

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -150,12 +150,19 @@
                       {% endif %}
                     {% endif %}
                   {%- endif -%}
+                  {% if nav_child.class_name %}
+                    {% assign nav_child_configured_class_name = nav_child.class_name %}
+                  {% else %}
+                    {% assign nav_child_configured_class_name = "" %}
+                  {% endif %}
                   <li>
                     <a href="{{ nav_child.url }}"
                       {% if page.url == nav_child.url -%}
-                        class="in-category"
+                        class="in-category {{ nav_child_configured_class_name }}"
                       {%- elsif child_url_fragment == url_fragment -%}
-                        class="in-category"
+                        class="in-category {{ nav_child_configured_class_name }}"
+                      {%- elsif nav_child_configured_class_name != "" -%}
+                        class="{{ nav_child_configured_class_name }}"
                       {%- endif %}
                     >{{ nav_child.label }}</a>
                   </li>
@@ -207,13 +214,13 @@
     const isMobile = window.matchMedia('only screen and (max-width: 834px)').matches;
 
     // Initialize the calendar view menu item to target the current month.
-    const calendarMenuItemSelector = '#top a[href*="/events/calendar/"]';
+    const calendarMenuItemSelector = '#top a.events-page-menu-link__device-based';
     const calendarMenuItem = document.querySelector(calendarMenuItemSelector);
     if (calendarMenuItem && !isMobile) {
       const now = new Date();
       const monthNumber = now.getUTCMonth() + 1;
       const year = now.getFullYear();
-      const thisMonthCalendarUrl = `/events/calendar/${year}-${monthNumber < 10 ? `0${monthNumber}` : monthNumber}`;
+      const thisMonthCalendarUrl = `/events/calendar/${year}-${monthNumber < 10 ? `0${monthNumber}` : monthNumber}.html`;
       calendarMenuItem.setAttribute('href',  thisMonthCalendarUrl);
     } else if (calendarMenuItem) {
       calendarMenuItem.setAttribute('href', '/events/index.html');

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -10,6 +10,9 @@ layout: fullwidth-with-breadcrumbs
 <template id="events-filter-chip">
     {% include filter-chips.html type="events" %}
 </template>
+<template id="empty-calendar-message">
+    <p class="events--calendar--no-events-message">No events scheduled at this time.</p>
+</template>
 
 {% assign start_date = page.date_of_first_sunday %}
 {% assign end_date = page.date_of_last_saturday %}
@@ -52,7 +55,7 @@ layout: fullwidth-with-breadcrumbs
                 {% include labeled-dropdown.html 
                     items=site.data.calendars.filter_categories 
                     label="Filter by Category" 
-                    id="category-filter-selector" 
+                    id="category-filter-selector"
                 %}
             </div>
             <div class="events--calendar--filters--category-selector--filter-chips"></div>
@@ -429,6 +432,13 @@ layout: fullwidth-with-breadcrumbs
             const expandedClassName = 'labeled-dropdown__expanded';
             const { currentTarget } = e;
             const parent = currentTarget.closest('.labeled-dropdown');
+            const selectElement = parent.querySelector('select');
+            if (selectElement?.hasAttribute?.('disabled')) {
+                e.stopImmediatePropagation();
+                e.stopPropagation();
+                e.preventDefault();
+                return;
+            }
             if (parent) {
                 if (parent.classList.contains(collapsedClassName)) {
                     parent.classList.replace(collapsedClassName, expandedClassName);
@@ -443,6 +453,10 @@ layout: fullwidth-with-breadcrumbs
         
         document.querySelector('.events--calendar--filters--category-selector--dropdown .labeled-dropdown--select')?.addEventListener?.('click', (e) => {
             const { currentTarget, target : { value = '' } = {} } = e;
+            if (currentTarget.hasAttribute('disabled')) {
+                e.preventDefault();
+                return;
+            }
             const filterCategories = {{ site.data.calendars.filter_categories | map: "value" | jsonify }};
             if (filterCategories.includes(value)) {
                 const calendarClass = 'events--calendar';
@@ -491,6 +505,11 @@ layout: fullwidth-with-breadcrumbs
         document.getElementById('in-person-toggle-button')?.addEventListener?.('click', (e) => {
             const { currentTarget } = e;
             const parent = currentTarget.closest('.events--calendar--filters--in-person-toggle');
+            const disabledClassName = 'events--calendar--filters--in-person-toggle__disabled';
+            if (parent.classList.contains(disabledClassName)) {
+                e.preventDefault();
+                return;
+            }
             parent.classList.toggle('events--calendar--filters--in-person-toggle__toggled-off');
             const calendar = document.querySelector('.events--calendar');
             calendar?.classList?.toggle?.('events--calendar__online-only');
@@ -756,9 +775,30 @@ layout: fullwidth-with-breadcrumbs
             }
         }
 
+        function conditionallyShowNoEventsMessage() {
+            const eventSelector = '.events--calendar--body--week--day--event';
+            const count = document.querySelectorAll(eventSelector).length;
+            if (count === 0) {
+                const emptyCalendarTemplate = document.getElementById('empty-calendar-message');
+                const templateContent = emptyCalendarTemplate.content.cloneNode(true);
+                const messageParentSelector = '.events--calendar--filters--category-selector--filter-chips';
+                const messageParentElement = document.querySelector(messageParentSelector);
+                messageParentElement?.appendChild?.(templateContent);
+                const categoryFilterDropdownId = 'category-filter-selectorFilter-by-Category';
+                const categoryFilterDropdownElement = document.getElementById(categoryFilterDropdownId);
+                categoryFilterDropdownElement?.setAttribute?.('disabled', '');
+                categoryFilterDropdownElement?.closest?.('.labeled-dropdown')?.classList?.add?.('labeled-dropdown__disabled');
+                const inPersonToggleClass = 'events--calendar--filters--in-person-toggle';
+                const inPersonToggleDisabledClass = `${inPersonToggleClass}__disabled`;
+                const inPersonToggleSelector = `.${inPersonToggleClass}`;
+                const inPersonToggleElement = document.querySelector(inPersonToggleSelector);
+                inPersonToggleElement?.classList?.add?.(inPersonToggleDisabledClass);
+            }
+        }
         setEventsPageLinksToThisMonthCalendar();
         localizeEventDates();
         initializeFilterStateDOM(readFilterState());
+        conditionallyShowNoEventsMessage();
         window.addEventListener('beforeunload', () => {
             writeFilterState();
         });

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -13,6 +13,9 @@ layout: fullwidth-with-breadcrumbs
 <template id="empty-calendar-message">
     <p class="events--calendar--no-events-message">No events scheduled at this time.</p>
 </template>
+<template id="empty-filter-results-message">
+    <p class="events--calendar--empty-filter-results-message">No events found, try adjusting your filters.</p>
+</template>
 
 {% assign start_date = page.date_of_first_sunday %}
 {% assign end_date = page.date_of_last_saturday %}
@@ -432,7 +435,7 @@ layout: fullwidth-with-breadcrumbs
             const expandedClassName = 'labeled-dropdown__expanded';
             const { currentTarget } = e;
             const parent = currentTarget.closest('.labeled-dropdown');
-            const selectElement = parent.querySelector('select');
+            const selectElement = parent?.querySelector('select');
             if (selectElement?.hasAttribute?.('disabled')) {
                 e.stopImmediatePropagation();
                 e.stopPropagation();
@@ -775,6 +778,18 @@ layout: fullwidth-with-breadcrumbs
             }
         }
 
+        function disableFilterControls() {
+            const categoryFilterDropdownId = 'category-filter-selectorFilter-by-Category';
+            const categoryFilterDropdownElement = document.getElementById(categoryFilterDropdownId);
+            categoryFilterDropdownElement?.setAttribute?.('disabled', '');
+            categoryFilterDropdownElement?.closest?.('.labeled-dropdown')?.classList?.add?.('labeled-dropdown__disabled');
+            const inPersonToggleClass = 'events--calendar--filters--in-person-toggle';
+            const inPersonToggleDisabledClass = `${inPersonToggleClass}__disabled`;
+            const inPersonToggleSelector = `.${inPersonToggleClass}`;
+            const inPersonToggleElement = document.querySelector(inPersonToggleSelector);
+            inPersonToggleElement?.classList?.add?.(inPersonToggleDisabledClass);
+        }
+
         function conditionallyShowNoEventsMessage() {
             const eventSelector = '.events--calendar--body--week--day--event';
             const count = document.querySelectorAll(eventSelector).length;
@@ -784,15 +799,7 @@ layout: fullwidth-with-breadcrumbs
                 const messageParentSelector = '.events--calendar--filters--category-selector--filter-chips';
                 const messageParentElement = document.querySelector(messageParentSelector);
                 messageParentElement?.appendChild?.(templateContent);
-                const categoryFilterDropdownId = 'category-filter-selectorFilter-by-Category';
-                const categoryFilterDropdownElement = document.getElementById(categoryFilterDropdownId);
-                categoryFilterDropdownElement?.setAttribute?.('disabled', '');
-                categoryFilterDropdownElement?.closest?.('.labeled-dropdown')?.classList?.add?.('labeled-dropdown__disabled');
-                const inPersonToggleClass = 'events--calendar--filters--in-person-toggle';
-                const inPersonToggleDisabledClass = `${inPersonToggleClass}__disabled`;
-                const inPersonToggleSelector = `.${inPersonToggleClass}`;
-                const inPersonToggleElement = document.querySelector(inPersonToggleSelector);
-                inPersonToggleElement?.classList?.add?.(inPersonToggleDisabledClass);
+                disableFilterControls();
             }
         }
         setEventsPageLinksToThisMonthCalendar();

--- a/_sass/_events-calendar.scss
+++ b/_sass/_events-calendar.scss
@@ -73,7 +73,23 @@ $calendar-month-default-week-count: 5;
         font-weight: 600;
         line-height: 14px;
     }
+    // NOTE: The selectors for the headers with the id's defined
+    //       is used as it has been observed that event authors are
+    //       free to use whatever HTML or Kramdown in the content, and
+    //       Jekyll will provide whatever is there lexicographicaly first
+    //       as an excerpt which can break the design. Jekyll creates id 
+    //       attributes for headers using a formatted version of the text of
+    //       the header. The card styles do not use id attributes. So, if there
+    //       is an id attribute then it is coming from the Jekyll excerpt.
+    //       Normalizing the presentation of the excerpts helps to keep the
+    //       design consistent.
     > p,
+    > h6[id],
+    > h5[id],
+    > h4[id],
+    > h3[id],
+    > h2[id],
+    > h1[id],
     .events--calendar--body--week--day--event--details--description {
         @include trim-ellipsis-multiline;
         color: #000;
@@ -241,6 +257,7 @@ $calendar-month-default-week-count: 5;
             column-gap: 10px;
             &.events--calendar--filters--in-person-toggle__disabled {
                 > div:nth-of-type(1) {
+                    cursor: not-allowed;
                     > svg {
                         > rect {
                             fill: $secondary-sanfrancisco-fog-s1;

--- a/_sass/_events-calendar.scss
+++ b/_sass/_events-calendar.scss
@@ -121,6 +121,15 @@ $calendar-month-default-week-count: 5;
 > div.events--calendar--wrapper {
     @include page-element-left-right-margins;
     padding: 0;
+    p.events--calendar--no-events-message {
+        @include body-text;
+        text-align: left;
+        white-space: nowrap;
+        overflow-x: visible;
+        &.events--calendar--no-events-message__centered {
+            text-align: center;
+        }
+    }
     > .events--calendar--filters {
         display: flex;
         flex-direction: row;
@@ -219,6 +228,9 @@ $calendar-month-default-week-count: 5;
                     flex-grow: 1;
                     flex-shrink: 1;
                 }
+                > p.events--calendar--no-events-message {
+                    line-height: 0;
+                }
             }
         }
         > .events--calendar--filters--in-person-toggle {
@@ -227,6 +239,23 @@ $calendar-month-default-week-count: 5;
             flex-wrap: nowrap;
             align-items: center;
             column-gap: 10px;
+            &.events--calendar--filters--in-person-toggle__disabled {
+                > div:nth-of-type(1) {
+                    > svg {
+                        > rect {
+                            fill: $secondary-sanfrancisco-fog-s1;
+                        }
+                        > circle {
+                            fill: #fff;
+                        }
+                    }
+                }
+                > div:nth-of-type(2) {
+                    > label {
+                        color: $secondary-sanfrancisco-fog-s1;
+                    }
+                }
+            }
             &.events--calendar--filters--in-person-toggle__toggled-off {
                 > div:nth-of-type(1) {
                     transform: rotateZ(180deg);

--- a/_sass/_labeled-dropdown.scss
+++ b/_sass/_labeled-dropdown.scss
@@ -7,6 +7,18 @@
     height: 35px;
     position: relative;
     box-sizing: border-box;
+    &.labeled-dropdown__disabled {
+        cursor: not-allowed;
+        > .labeled-dropdown--label-arrow {
+            > div:nth-of-type(1) > label {
+                cursor: not-allowed;
+                color: $secondary-sanfrancisco-fog-s1;
+            }
+            > div:nth-of-type(2) > svg > path {
+                fill: $secondary-sanfrancisco-fog-s1;
+            }
+        }
+    }
     > .labeled-dropdown--select {
         position: absolute;
         top: 33px;

--- a/_sass/_labeled-dropdown.scss
+++ b/_sass/_labeled-dropdown.scss
@@ -7,6 +7,7 @@
     height: 35px;
     position: relative;
     box-sizing: border-box;
+    cursor: pointer;
     &.labeled-dropdown__disabled {
         cursor: not-allowed;
         > .labeled-dropdown--label-arrow {
@@ -62,6 +63,7 @@
                 > label {
                     @include header-level5($primary-open-sky-s2);
                     padding-left: 10px;
+                    cursor: pointer;
                 }
             }
             &:nth-of-type(2) {
@@ -73,6 +75,7 @@
                 flex-direction: column;
                 box-sizing: border-box;
                 padding-right: 5px;
+                cursor: pointer;
                 > svg {
                     > path {
                         fill: $primary-open-sky-s2;

--- a/events/index.html
+++ b/events/index.html
@@ -177,8 +177,9 @@ callouts:
   function setEventsPageLinksToThisMonthCalendar() {
     const today = new Date();
     const monthIndex = today.getUTCMonth();
+    const monthNumber = monthIndex + 1;
     const year = today.getUTCFullYear();
-    const calendarViewUrl = `/events/calendar/${year}-${monthIndex + 1}.html`;
+    const calendarViewUrl = `/events/calendar/${year}-${monthNumber < 10 ? `0${monthNumber}` : monthNumber}.html`;
     setCalendarViewToggleUrlToThisMonth(calendarViewUrl);
     setEventsBreadcrumbsUrlToThisMonth(calendarViewUrl);
     setCalendarLinkToThisMonth(calendarViewUrl);

--- a/events/index.html
+++ b/events/index.html
@@ -151,270 +151,334 @@ callouts:
 <script type="module">
   document.addEventListener('DOMContentLoaded', () => {
 
-    function setEventsBreadcrumbsUrlToThisMonth(calendarViewUrl) {
-      const selector = '.full-width-layout--header--breadcrumbs--item > a[href*="/events/calendar/"]';
-      const link = document.querySelector(selector);
-      link?.setAttribute?.('href', calendarViewUrl);
-    }
+  function setEventsBreadcrumbsUrlToThisMonth(calendarViewUrl) {
+    const selector = '.full-width-layout--header--breadcrumbs--item > a[href*="/events/calendar/"]';
+    const link = document.querySelector(selector);
+    link?.setAttribute?.('href', calendarViewUrl);
+  }
 
-    function setCalendarViewToggleUrlToThisMonth(calendarViewUrl) {
-      const selector = '.events--calendar--filters--view-mode-toggle--item:first-of-type > a';
-      const toggleButton = document.querySelector(selector);
-      toggleButton?.setAttribute?.('href', calendarViewUrl);
+  function setCalendarViewToggleUrlToThisMonth(calendarViewUrl) {
+    const selector = '.events--calendar--filters--view-mode-toggle--item:first-of-type > a';
+    const toggleButton = document.querySelector(selector);
+    toggleButton?.setAttribute?.('href', calendarViewUrl);
+  }
+
+  function setCalendarLinkToThisMonth(calendarViewUrl) {
+    const attributeName = 'data-eventscalendarlink';
+    const attributeSelector = `[${attributeName}="true"]`;
+    const elements = document.querySelectorAll(attributeSelector);
+    if (elements?.length) {
+      elements.forEach(element => {
+        element.setAttribute('href', calendarViewUrl);
+      });
     }
-    
-    function setCalendarLinkToThisMonth(calendarViewUrl) {
-      const attributeName = 'data-eventscalendarlink';
-      const attributeSelector = `[${attributeName}="true"]`;
-      const elements = document.querySelectorAll(attributeSelector);
-      if (elements?.length) {
-        elements.forEach(element => {
-          element.setAttribute('href', calendarViewUrl);
-        });
+  }
+
+  function setEventsPageLinksToThisMonthCalendar() {
+    const today = new Date();
+    const monthIndex = today.getUTCMonth();
+    const year = today.getUTCFullYear();
+    const calendarViewUrl = `/events/calendar/${year}-${monthIndex + 1}.html`;
+    setCalendarViewToggleUrlToThisMonth(calendarViewUrl);
+    setEventsBreadcrumbsUrlToThisMonth(calendarViewUrl);
+    setCalendarLinkToThisMonth(calendarViewUrl);
+  }
+
+  function hasFilterChip(chipType) {
+      const selector = `.events--calendar--filters--category-selector--filter-chips > [data-category=${chipType}]`;
+      const chipElement = document.querySelector(selector);
+      return chipElement !== null;
+  }
+
+  function hasAnyFilterChips() {
+      const selector = '.events--calendar--filters--category-selector--filter-chips > .filter-chip';
+      const chips = document.querySelectorAll(selector);
+      const chipCount = chips?.length ?? 0;
+      return chipCount > 0;
+  }
+
+  function updateFilterByCategoryLabelCount() {
+      const filterChipsParent = document.querySelector('.events--calendar--filters--category-selector--filter-chips');
+      const chipCount = filterChipsParent?.querySelectorAll?.('.filter-chip')?.length ?? 0;
+      const defaultLabelText = 'Filter by Category';
+      const labelSelector = '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--label';
+      const label = document.querySelector(labelSelector);
+      if (chipCount > 0) {    
+          const labelTextWithCount = `${defaultLabelText} (${chipCount})`;
+          label.textContent = labelTextWithCount;
+      } else {
+          label.textContent = defaultLabelText;
       }
-    }
+  }
 
-    function setEventsPageLinksToThisMonthCalendar() {
-      const today = new Date();
-      const monthIndex = today.getUTCMonth();
-      const year = today.getUTCFullYear();
-      const calendarViewUrl = `/events/calendar/${year}-${monthIndex + 1}.html`;
-      setCalendarViewToggleUrlToThisMonth(calendarViewUrl);
-      setEventsBreadcrumbsUrlToThisMonth(calendarViewUrl);
-      setCalendarLinkToThisMonth(calendarViewUrl);
-    }
+  function removeFilterChip(chipType) {
+      const selector = `.events--calendar--filters--category-selector--filter-chips > [data-category=${chipType}]`;
+      const chipElement = document.querySelector(selector);
+      chipElement?.parentElement?.removeChild?.(chipElement);
+      updateFilterByCategoryLabelCount();
+  }
 
-    function hasFilterChip(chipType) {
-        const selector = `.events--calendar--filters--category-selector--filter-chips > [data-category=${chipType}]`;
-        const chipElement = document.querySelector(selector);
-        return chipElement !== null;
-    }
+  function hideFilterDropdown() {
+      const selector = '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--select';
+      const dropdown = document.querySelector(selector);
+      const parent = dropdown.closest('.labeled-dropdown');
+      if (parent) {
+          const collapsedClassName = 'labeled-dropdown__collapsed';
+          const expandedClassName = 'labeled-dropdown__expanded';
+          parent.classList.replace(expandedClassName, collapsedClassName);
+      }
+  }
 
-    function hasAnyFilterChips() {
-        const selector = '.events--calendar--filters--category-selector--filter-chips > .filter-chip';
-        const chips = document.querySelectorAll(selector);
-        const chipCount = chips?.length ?? 0;
-        return chipCount > 0;
-    }
+  function addFilterChip(chipType) {
+      const templateId = `${chipType}-filter-chip`;
+      const chipTemplate = document.getElementById(templateId);
+      if (chipTemplate) {
+          const templateContent = chipTemplate.content.cloneNode(true);
+          const filterChipsParent = document.querySelector('.events--calendar--filters--category-selector--filter-chips');
+          filterChipsParent?.appendChild(templateContent);
+          updateFilterByCategoryLabelCount();
+      }
+  }
 
-    function updateFilterByCategoryLabelCount() {
-        const filterChipsParent = document.querySelector('.events--calendar--filters--category-selector--filter-chips');
-        const chipCount = filterChipsParent?.querySelectorAll?.('.filter-chip')?.length ?? 0;
-        const defaultLabelText = 'Filter by Category';
-        const labelSelector = '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--label';
-        const label = document.querySelector(labelSelector);
-        if (chipCount > 0) {    
-            const labelTextWithCount = `${defaultLabelText} (${chipCount})`;
-            label.textContent = labelTextWithCount;
-        } else {
-            label.textContent = defaultLabelText;
-        }
-    }
+  function removeClickedFilterChip(e) {
+      const { target } = e;
+      const clickedChipSelector = '.filter-chip';
+      const clickedChip = target.closest(clickedChipSelector);
+      if (clickedChip) {
+          const category = clickedChip.getAttribute('data-category');
+          const calendarClass = 'events--calendar__list-view';
+          const calendarSelector = `.${calendarClass}`;
+          const calendarFilteredModifierClass = `${calendarClass}__filtered`;
+          const calendar = document.querySelector(calendarSelector);
+          if (calendar) {
+              const categoryAttribute = 'data-filtercategory';
+              const filteredCategory = calendar.getAttribute(categoryAttribute);
+              if (filteredCategory) {
+                  const updatedFilters = filteredCategory.split(',').filter(value => value !== category).join(',');
+                  if (updatedFilters.length > 0) {
+                      calendar.setAttribute(categoryAttribute, updatedFilters);
+                  } else {
+                      calendar.removeAttribute(categoryAttribute);
+                      calendar.classList.remove(calendarFilteredModifierClass);
+                  }
+              }
+          }
+          removeFilterChip(category);
+      }
+      setTimeout(showEmptyMonthMessages, 60);
+  }
 
-    function removeFilterChip(chipType) {
-        const selector = `.events--calendar--filters--category-selector--filter-chips > [data-category=${chipType}]`;
-        const chipElement = document.querySelector(selector);
-        chipElement?.parentElement?.removeChild?.(chipElement);
-        updateFilterByCategoryLabelCount();
-    }
+  function toggleCategoryDropdown(e) {
+      const collapsedClassName = 'labeled-dropdown__collapsed';
+      const expandedClassName = 'labeled-dropdown__expanded';
+      const { currentTarget } = e;
+      const parent = currentTarget.closest('.labeled-dropdown');
+      const selectElement = parent?.querySelector('select');
+      if (selectElement?.hasAttribute?.('disabled')) {
+          e.stopImmediatePropagation();
+          e.stopPropagation();
+          e.preventDefault();
+          return;
+      }
+      if (parent) {
+          if (parent.classList.contains(collapsedClassName)) {
+              parent.classList.replace(collapsedClassName, expandedClassName);
+          } else {
+              parent.classList.replace(expandedClassName, collapsedClassName);
+          }
+      }
+      e.stopImmediatePropagation();
+      e.stopPropagation();
+      e.preventDefault();
+  }
 
-    function hideFilterDropdown() {
-        const selector = '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--select';
-        const dropdown = document.querySelector(selector);
-        const parent = dropdown.closest('.labeled-dropdown');
-        if (parent) {
-            const collapsedClassName = 'labeled-dropdown__collapsed';
-            const expandedClassName = 'labeled-dropdown__expanded';
-            parent.classList.replace(expandedClassName, collapsedClassName);
-        }
-    }
-    
-    function addFilterChip(chipType) {
-        const templateId = `${chipType}-filter-chip`;
-        const chipTemplate = document.getElementById(templateId);
-        if (chipTemplate) {
-            const templateContent = chipTemplate.content.cloneNode(true);
-            const filterChipsParent = document.querySelector('.events--calendar--filters--category-selector--filter-chips');
-            filterChipsParent?.appendChild(templateContent);
-            updateFilterByCategoryLabelCount();
-        }
-    }
+  function toggleCategoryFilterSelection(e) {
+      const { currentTarget, target : { value = '' } = {} } = e;
+      if (currentTarget.hasAttribute('disabled')) {
+          e.preventDefault();
+          return;
+      }
+      const filterCategories = {{ site.data.calendars.filter_categories | map: "value" | jsonify }};
+      if (filterCategories.includes(value)) {
+          const calendarClass = 'events--calendar__list-view';
+          const calendarSelector = `.${calendarClass}`;
+          const calendarFilteredModifierClass = `${calendarClass}__filtered`;
+          const calendar = document.querySelector(calendarSelector);
+          const adding = !hasFilterChip(value);
+          const filterAttribute = 'data-filtercategory';
+          if (adding) {
+              addFilterChip(value);
+          } else {
+              removeFilterChip(value);
+          }
+          if (hasAnyFilterChips()) {
+              if (calendar.hasAttribute(filterAttribute)) {
+                  const existingFilters = calendar.getAttribute(filterAttribute);
+                  if (adding) {
+                      const updatedFilters = [...existingFilters.split(','), value].join(',');
+                      calendar.setAttribute(filterAttribute, updatedFilters);
+                  } else {
+                      const updatedFilters = existingFilters.split(',').filter(category => category !== value);
+                      if (updatedFilters.length > 0) {
+                          calendar.setAttribute(filterAttribute, updatedFilters.join(','));
+                          if (!calendar.classList.contains(calendarFilteredModifierClass)) {
+                              calendar.classList.add(calendarFilteredModifierClass);
+                          }
+                      } else {
+                          calendar.removeAttribute(filterAttribute);
+                          calendar.classList.remove(calendarFilteredModifierClass);
+                      }
+                  }
+              } else {
+                  calendar.setAttribute(filterAttribute, value);
+                  if (!calendar.classList.contains(calendarFilteredModifierClass)) {
+                      calendar.classList.add(calendarFilteredModifierClass);
+                  }
+              }
+          } else {
+              calendar.removeAttribute(filterAttribute);
+              calendar.classList.remove(calendarFilteredModifierClass);
+          }
+      }
+      hideFilterDropdown();
+      setTimeout(showEmptyMonthMessages, 60);
+  }
 
-    function removeClickedFilterChip(e) {
-        const { target } = e;
-        const clickedChipSelector = '.filter-chip';
-        const clickedChip = target.closest(clickedChipSelector);
-        if (clickedChip) {
-            const category = clickedChip.getAttribute('data-category');
-            const calendarClass = 'events--calendar__list-view';
-            const calendarSelector = `.${calendarClass}`;
-            const calendarFilteredModifierClass = `${calendarClass}__filtered`;
-            const calendar = document.querySelector(calendarSelector);
-            if (calendar) {
-                const categoryAttribute = 'data-filtercategory';
-                const filteredCategory = calendar.getAttribute(categoryAttribute);
-                if (filteredCategory) {
-                    const updatedFilters = filteredCategory.split(',').filter(value => value !== category).join(',');
-                    if (updatedFilters.length > 0) {
-                        calendar.setAttribute(categoryAttribute, updatedFilters);
-                    } else {
-                        calendar.removeAttribute(categoryAttribute);
-                        calendar.classList.remove(calendarFilteredModifierClass);
-                    }
-                }
-            }
-            removeFilterChip(category);
-        }
-    }
+  function localizeEventDates() {
+    const eventDateAttributeName = 'data-eventdate';
+    const selector = `[${eventDateAttributeName}]`;
+    const eventDateElements = document.querySelectorAll(selector);
+    if (eventDateElements?.length) {
+      eventDateElements.forEach(dateElement => {
+        const eventDateValue = dateElement.getAttribute(eventDateAttributeName);
+        // example 2023-12-28 12:00:00 -0500
+        const datePartsPattern = /^(\d{4}-\d{1,2}-\d{1,2})\s+(\d{1,2}:\d{1,2}:\d{1,2})\s+(\+|-)(\d{2}:?\d{2}?)$/;
+        //const datePartsPattern = /^(\d{4}-\d{1,2}-\d{1,2})\s+(\d{1,2}:\d{1,2}:\d{1,2})$/;
+        const datePartsPatternMatches = datePartsPattern.exec(eventDateValue);
+        if (datePartsPatternMatches) {
+          const [ , datePartMatch, timePartMatch, utcOffsetOperatorMatch, utcOffsetMatch] = datePartsPatternMatches;
+          const [year, monthNumber, day] = datePartMatch.split('-').map(part => Number.parseInt(part, 10));
+          const monthIndex = monthNumber - 1;
+          const [hour, minute, second] = timePartMatch.split(':').map(part => Number.parseInt(part, 10));
+          const eventUtcTimestamp = Date.UTC(year, monthIndex, day, hour, minute, second);
 
-    function toggleCategoryDropdown(e) {
-        const collapsedClassName = 'labeled-dropdown__collapsed';
-        const expandedClassName = 'labeled-dropdown__expanded';
-        const { currentTarget } = e;
-        const parent = currentTarget.closest('.labeled-dropdown');
-        if (parent) {
-            if (parent.classList.contains(collapsedClassName)) {
-                parent.classList.replace(collapsedClassName, expandedClassName);
-            } else {
-                parent.classList.replace(expandedClassName, collapsedClassName);
-            }
-        }
-        e.stopImmediatePropagation();
-        e.stopPropagation();
-        e.preventDefault();
-    }
-
-    function toggleCategoryFilterSelection(e) {
-        const { currentTarget, target : { value = '' } = {} } = e;
-        const filterCategories = {{ site.data.calendars.filter_categories | map: "value" | jsonify }};
-        if (filterCategories.includes(value)) {
-            const calendarClass = 'events--calendar__list-view';
-            const calendarSelector = `.${calendarClass}`;
-            const calendarFilteredModifierClass = `${calendarClass}__filtered`;
-            const calendar = document.querySelector(calendarSelector);
-            const adding = !hasFilterChip(value);
-            const filterAttribute = 'data-filtercategory';
-            if (adding) {
-                addFilterChip(value);
-            } else {
-                removeFilterChip(value);
-            }
-            if (hasAnyFilterChips()) {
-                if (calendar.hasAttribute(filterAttribute)) {
-                    const existingFilters = calendar.getAttribute(filterAttribute);
-                    if (adding) {
-                        const updatedFilters = [...existingFilters.split(','), value].join(',');
-                        calendar.setAttribute(filterAttribute, updatedFilters);
-                    } else {
-                        const updatedFilters = existingFilters.split(',').filter(category => category !== value);
-                        if (updatedFilters.length > 0) {
-                            calendar.setAttribute(filterAttribute, updatedFilters.join(','));
-                            if (!calendar.classList.contains(calendarFilteredModifierClass)) {
-                                calendar.classList.add(calendarFilteredModifierClass);
-                            }
-                        } else {
-                            calendar.removeAttribute(filterAttribute);
-                            calendar.classList.remove(calendarFilteredModifierClass);
-                        }
-                    }
-                } else {
-                    calendar.setAttribute(filterAttribute, value);
-                    if (!calendar.classList.contains(calendarFilteredModifierClass)) {
-                        calendar.classList.add(calendarFilteredModifierClass);
-                    }
-                }
-            } else {
-                calendar.removeAttribute(filterAttribute);
-                calendar.classList.remove(calendarFilteredModifierClass);
-            }
-        }
-        hideFilterDropdown();
-    }
-
-    function localizeEventDates() {
-      const eventDateAttributeName = 'data-eventdate';
-      const selector = `[${eventDateAttributeName}]`;
-      const eventDateElements = document.querySelectorAll(selector);
-      if (eventDateElements?.length) {
-        eventDateElements.forEach(dateElement => {
-          const eventDateValue = dateElement.getAttribute(eventDateAttributeName);
-          // example 2023-12-28 12:00:00 -0500
-          const datePartsPattern = /^(\d{4}-\d{1,2}-\d{1,2})\s+(\d{1,2}:\d{1,2}:\d{1,2})\s+(\+|-)(\d{2}:?\d{2}?)$/;
-          //const datePartsPattern = /^(\d{4}-\d{1,2}-\d{1,2})\s+(\d{1,2}:\d{1,2}:\d{1,2})$/;
-          const datePartsPatternMatches = datePartsPattern.exec(eventDateValue);
-          if (datePartsPatternMatches) {
-            const [ , datePartMatch, timePartMatch, utcOffsetOperatorMatch, utcOffsetMatch] = datePartsPatternMatches;
-            const [year, monthNumber, day] = datePartMatch.split('-').map(part => Number.parseInt(part, 10));
-            const monthIndex = monthNumber - 1;
-            const [hour, minute, second] = timePartMatch.split(':').map(part => Number.parseInt(part, 10));
-            const eventUtcTimestamp = Date.UTC(year, monthIndex, day, hour, minute, second);
-
-            let utcHoursOffset = 0, utcMinutesOffset = 0;
-            if (utcOffsetMatch.indexOf(':') > -1) {
-              const splitUtcOffsetMatch = utcOffsetMatch.split(':').map(part => {
+          let utcHoursOffset = 0, utcMinutesOffset = 0;
+          if (utcOffsetMatch.indexOf(':') > -1) {
+            const splitUtcOffsetMatch = utcOffsetMatch.split(':').map(part => {
                 return Number.parseInt(part.replace(/^0+/, ''), 10);
-              });
-              utcHoursOffset = splitUtcOffsetMatch[0];
-              utcMinutesOffset = splitUtcOffsetMatch[1];
-            } else {
-              const splitUtcOffsetPattern = /^(\d{2})(\d{2}?)$/;
-              const splitUtcOffsetMatches = splitUtcOffsetPattern.exec(utcOffsetMatch);
-              if (splitUtcOffsetMatches?.length) {
+            });
+            utcHoursOffset = splitUtcOffsetMatch[0];
+            utcMinutesOffset = splitUtcOffsetMatch[1];
+          } else {
+            const splitUtcOffsetPattern = /^(\d{2})(\d{2}?)$/;
+            const splitUtcOffsetMatches = splitUtcOffsetPattern.exec(utcOffsetMatch);
+            if (splitUtcOffsetMatches?.length) {
                 const utcOffsetsNumbers = splitUtcOffsetMatches.slice(1).map(part => {
-                  return Number.parseInt(part.replace(/^0+/, ''), 10);
+                return Number.parseInt(part.replace(/^0+/, ''), 10);
                 });
                 utcHoursOffset = utcOffsetsNumbers[0];
                 utcMinutesOffset = utcOffsetsNumbers[1] || 0;
-              }
             }
-            const timezoneOffset = (
-              1000 * 60 * 60 * utcHoursOffset
-            ) + (
-              1000 * 60 * utcMinutesOffset
-            ) * (
-              utcOffsetOperatorMatch === '-' ? -1 : 1
-            );
-            const eventUtcDate = new Date(eventUtcTimestamp + timezoneOffset);
-            const formatter = new Intl.DateTimeFormat(navigator.language, {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-              dayPeriod: 'long',
-              hour: 'numeric',
-              hourCycle: 'h12',
-              minute: 'numeric',
-              timeZoneName: 'short',
-            });
-            dateElement.textContent = formatter.format(eventUtcDate);
           }
-        });
-      }
+          const timezoneOffset = (
+            1000 * 60 * 60 * utcHoursOffset
+          ) + (
+            1000 * 60 * utcMinutesOffset
+          ) * (
+            utcOffsetOperatorMatch === '-' ? -1 : 1
+          );
+          const eventUtcDate = new Date(eventUtcTimestamp + timezoneOffset);
+          const formatter = new Intl.DateTimeFormat(navigator.language, {
+            weekday: 'long',
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            dayPeriod: 'long',
+            hour: 'numeric',
+            hourCycle: 'h12',
+            minute: 'numeric',
+            timeZoneName: 'short',
+          });
+          dateElement.textContent = formatter.format(eventUtcDate);
+        }
+      });
     }
+  }
 
-    document.querySelector(
-        '.events--calendar--filters--category-selector--filter-chips'
-    )?.addEventListener?.('click', removeClickedFilterChip);
-
-    document.querySelector(
-        '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--label-arrow'
-    )?.addEventListener?.('click', toggleCategoryDropdown);
-
-    document.querySelector(
-        '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--select'
-    )?.addEventListener?.('click', toggleCategoryFilterSelection);
-    
-    document.getElementById('in-person-toggle-button')?.addEventListener?.('click', (e) => {
-        const { currentTarget } = e;
-        const parent = currentTarget.closest('.events--calendar--filters--in-person-toggle');
-        parent.classList.toggle('events--calendar--filters--in-person-toggle__toggled-off');
-        const calendar = document.querySelector('.events--calendar__list-view');
-        calendar?.classList?.toggle?.('events--calendar__list-view__online-only');
+  function showEmptyMonthMessages() {
+    const monthContainerSelector = '.events--calendar__list-view .solutions-card-grid';
+    const eventsCardMonthWrapperSelector = '.events--calendar__list-view--card-wrapper';
+    const monthContainerElements = document.querySelectorAll(monthContainerSelector);
+    monthContainerElements.forEach(monthContainerElement => {
+      const cardWrapper = monthContainerElement.querySelector(eventsCardMonthWrapperSelector);
+      const eventCardSelector = '.events--calendar--details--card';
+      const eventCardElements = Array.from(cardWrapper?.querySelectorAll?.(eventCardSelector) ?? []);
+      const monthIsEmpty = eventCardElements.every(monthCardElement => {
+        const { clientHeight } = monthCardElement;
+        return clientHeight === 0;
+      });
+      if (monthIsEmpty) {
+        const emptyFilterResultsMessage = monthContainerElement.querySelector('p.events--calendar--empty-filter-results-message');
+        if (emptyFilterResultsMessage) {
+          emptyFilterResultsMessage.style.display = 'block';
+        } else {
+          const emptyFilterResultsMessageTemplate = document.getElementById('empty-filter-results-message');
+          monthContainerElement.appendChild(emptyFilterResultsMessageTemplate.content.cloneNode(true));
+        }
+      } else {
+        const emptyFilterResultsMessage = monthContainerElement.querySelector('p.events--calendar--empty-filter-results-message');
+        if (emptyFilterResultsMessage) {
+          emptyFilterResultsMessage.style.display = 'none';
+        }
+      }
     });
+  }
 
-    setEventsPageLinksToThisMonthCalendar();
-    localizeEventDates();
+  function disableFilterControls() {
+    const categoryFilterDropdownId = 'category-filter-selectorFilter-by-Category';
+    const categoryFilterDropdownElement = document.getElementById(categoryFilterDropdownId);
+    categoryFilterDropdownElement?.setAttribute?.('disabled', '');
+    categoryFilterDropdownElement?.closest?.('.labeled-dropdown')?.classList?.add?.('labeled-dropdown__disabled');
+    const inPersonToggleClass = 'events--calendar--filters--in-person-toggle';
+    const inPersonToggleDisabledClass = `${inPersonToggleClass}__disabled`;
+    const inPersonToggleSelector = `.${inPersonToggleClass}`;
+    const inPersonToggleElement = document.querySelector(inPersonToggleSelector);
+    inPersonToggleElement?.classList?.add?.(inPersonToggleDisabledClass);
+  }
+
+  document.querySelector(
+      '.events--calendar--filters--category-selector--filter-chips'
+  )?.addEventListener?.('click', removeClickedFilterChip);
+
+  document.querySelector(
+      '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--label-arrow'
+  )?.addEventListener?.('click', toggleCategoryDropdown);
+
+  document.querySelector(
+      '.events--calendar--filters--category-selector--dropdown .labeled-dropdown--select'
+  )?.addEventListener?.('click', toggleCategoryFilterSelection);
+
+  document.getElementById('in-person-toggle-button')?.addEventListener?.('click', (e) => {
+      const { currentTarget } = e;
+      const parent = currentTarget.closest('.events--calendar--filters--in-person-toggle');
+      const disabledClassName = 'events--calendar--filters--in-person-toggle__disabled';
+      if (parent.classList.contains(disabledClassName)) {
+          e.preventDefault();
+          return;
+      }
+      parent.classList.toggle('events--calendar--filters--in-person-toggle__toggled-off');
+      const calendar = document.querySelector('.events--calendar__list-view');
+      calendar?.classList?.toggle?.('events--calendar__list-view__online-only');
+      setTimeout(showEmptyMonthMessages, 60);
   });
+
+  const sortedEventsCount = {{ sorted_events_count }};
+  setEventsPageLinksToThisMonthCalendar();
+  localizeEventDates();
+  if (sortedEventsCount == 0) {
+    disableFilterControls();
+  }
+});
 </script>
 {% include card-clickability.html 
   card_classname="events--calendar--details--card" 

--- a/events/index.html
+++ b/events/index.html
@@ -67,53 +67,58 @@ callouts:
     {% assign sorted_events = future_events | sort: "eventdate" %}
     {% assign current_month = "" %}
     {% assign current_year = "" %}
-    {% for event in sorted_events %}
-      
-      {% assign current_event_date_parts = event.eventdate | split: "-" %}
-      {% if current_event_date_parts[0] != current_year or current_event_date_parts[1] != current_month %}
-        {% assign current_year = current_event_date_parts[0] %}
-        {% assign current_month = current_event_date_parts[1] %}
-        <div class="solutions-card-grid">
-          <h2>{{ event.eventdate | date: "%b %Y"}}</h2>
-          <div class="events--calendar__list-view--card-wrapper">
-      {% endif %}
+    {% assign sorted_events_count = sorted_events | size %}
+    {% if sorted_events_count == 0 %}
+      <p class="events--calendar--no-events-message events--calendar--no-events-message__centered">No events scheduled at this time.</p>
+    {% else %}
+      {% for event in sorted_events %}
+        
+        {% assign current_event_date_parts = event.eventdate | split: "-" %}
+        {% if current_event_date_parts[0] != current_year or current_event_date_parts[1] != current_month %}
+          {% assign current_year = current_event_date_parts[0] %}
+          {% assign current_month = current_event_date_parts[1] %}
+          <div class="solutions-card-grid">
+            <h2>{{ event.eventdate | date: "%b %Y"}}</h2>
+            <div class="events--calendar__list-view--card-wrapper">
+        {% endif %}
 
-      {% assign category = event.category | default: "community" %}
-      {% assign event_date = event.eventdate | date: "%a %d %b %Y at %I:%M %p %Z" %}
-      {% assign category_card_class = "events--calendar__list-view--event-card__" | append: category %}
-      {% assign online_event_card_class = "events--calendar__list-view--event-card__online" %}
-      {% if event.online %}
-        {% assign category_card_class = category_card_class | append: " " | append: online_event_card_class %}
-      {% endif %}
-      <div class="events--calendar--details--card {{ category_card_class }} solutions-card-grid--card-wrapper--card">
-        <h4 class="events--calendar--body--week--day--event--details--category">
-            {{ category }}
-        </h4>
-        <h3 class="events--calendar--body--week--day--event--details--name">
-          <a href="{{ event.url }}">{{ event.title }}</a>
-        </h3>
-        <h6 class="events--calendar--body--week--day--event--details--date" data-eventdate="{{ event.eventdate }}">
-            {{ event.eventdate | date: "%a %d %b %Y at %I:%M %p %Z" }}
-        </h6>
-        {% if event.excerpt %}
-            {{ event.excerpt }}
-        {% else %}
-            {{ event.content }}
+        {% assign category = event.category | default: "community" %}
+        {% assign event_date = event.eventdate | date: "%a %d %b %Y at %I:%M %p %Z" %}
+        {% assign category_card_class = "events--calendar__list-view--event-card__" | append: category %}
+        {% assign online_event_card_class = "events--calendar__list-view--event-card__online" %}
+        {% if event.online %}
+          {% assign category_card_class = category_card_class | append: " " | append: online_event_card_class %}
         {% endif %}
-        <h5 class="events--calendar--body--week--day--event--details--host"><a href="{{ event.url }}">Learn more</a></h5>
-      </div>
-      
-      {% if forloop.last %}
-        </div></div>
-      {% else %}
-        {% assign peak_ahead_index = forloop.index0 | plus: 1%}
-        {% assign peak_ahead_date = sorted_events[peak_ahead_index].eventdate %}
-        {% assign peak_ahead_date_parts = peak_ahead_date | split: "-" %}
-        {% if peak_ahead_date_parts[0] != current_event_date_parts[0] or peak_ahead_date_parts[1] != current_event_date_parts[1] %}
+        <div class="events--calendar--details--card {{ category_card_class }} solutions-card-grid--card-wrapper--card">
+          <h4 class="events--calendar--body--week--day--event--details--category">
+              {{ category }}
+          </h4>
+          <h3 class="events--calendar--body--week--day--event--details--name">
+            <a href="{{ event.url }}">{{ event.title }}</a>
+          </h3>
+          <h6 class="events--calendar--body--week--day--event--details--date" data-eventdate="{{ event.eventdate }}">
+              {{ event.eventdate | date: "%a %d %b %Y at %I:%M %p %Z" }}
+          </h6>
+          {% if event.excerpt %}
+              {{ event.excerpt }}
+          {% else %}
+              {{ event.content }}
+          {% endif %}
+          <h5 class="events--calendar--body--week--day--event--details--host"><a href="{{ event.url }}">Learn more</a></h5>
+        </div>
+        
+        {% if forloop.last %}
           </div></div>
+        {% else %}
+          {% assign peak_ahead_index = forloop.index0 | plus: 1%}
+          {% assign peak_ahead_date = sorted_events[peak_ahead_index].eventdate %}
+          {% assign peak_ahead_date_parts = peak_ahead_date | split: "-" %}
+          {% if peak_ahead_date_parts[0] != current_event_date_parts[0] or peak_ahead_date_parts[1] != current_event_date_parts[1] %}
+            </div></div>
+          {% endif %}
         {% endif %}
-      {% endif %}
-    {% endfor %}
+      {% endfor %}
+    {% endif %}
   </div>
   <div class="events--calendar--more">
     <div class="conference-speakers--session-speakers--more--link-button">
@@ -121,7 +126,6 @@ callouts:
     </div>
   </div>
 </div>
-
 <div class="events--secondary-content">
   {% include callout-cards.html 
     heading="Hosting an OpenSearch event?" 
@@ -407,6 +411,7 @@ callouts:
         const calendar = document.querySelector('.events--calendar__list-view');
         calendar?.classList?.toggle?.('events--calendar__list-view__online-only');
     });
+
     setEventsPageLinksToThisMonthCalendar();
     localizeEventDates();
   });

--- a/events/past.html
+++ b/events/past.html
@@ -181,8 +181,9 @@ callouts:
     function setEventsPageLinksToThisMonthCalendar() {
       const today = new Date();
       const monthIndex = today.getUTCMonth();
+      const monthNumber = monthIndex + 1;
       const year = today.getUTCFullYear();
-      const calendarViewUrl = `/events/calendar/${year}-${monthIndex + 1}.html`;
+      const calendarViewUrl = `/events/calendar/${year}-${monthNumber < 10 ? `0${monthNumber}` : monthNumber}.html`;
       setCalendarViewToggleUrlToThisMonth(calendarViewUrl);
       setEventsBreadcrumbsUrlToThisMonth(calendarViewUrl);
       setCalendarLinkToThisMonth(calendarViewUrl);

--- a/events/past.html
+++ b/events/past.html
@@ -25,6 +25,10 @@ callouts:
 <template id="events-filter-chip">
   {% include filter-chips.html type="events" %}
 </template>
+<template id="empty-filter-results-message">
+    <p class="events--calendar--empty-filter-results-message">No events found, try adjusting your filters.</p>
+</template>
+
 <div class="events--calendar--wrapper">
   <div class="events--calendar--filters">
     <div class="events--calendar--filters--view-mode-toggle">
@@ -265,6 +269,7 @@ callouts:
             }
             removeFilterChip(category);
         }
+        setTimeout(showEmptyMonthMessages, 60);
     }
 
     function toggleCategoryDropdown(e) {
@@ -272,6 +277,13 @@ callouts:
         const expandedClassName = 'labeled-dropdown__expanded';
         const { currentTarget } = e;
         const parent = currentTarget.closest('.labeled-dropdown');
+        const selectElement = parent?.querySelector('select');
+        if (selectElement?.hasAttribute?.('disabled')) {
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            e.preventDefault();
+            return;
+        }
         if (parent) {
             if (parent.classList.contains(collapsedClassName)) {
                 parent.classList.replace(collapsedClassName, expandedClassName);
@@ -286,6 +298,10 @@ callouts:
 
     function toggleCategoryFilterSelection(e) {
         const { currentTarget, target : { value = '' } = {} } = e;
+        if (currentTarget.hasAttribute('disabled')) {
+            e.preventDefault();
+            return;
+        }
         const filterCategories = {{ site.data.calendars.filter_categories | map: "value" | jsonify }};
         if (filterCategories.includes(value)) {
             const calendarClass = 'events--calendar__list-view';
@@ -329,6 +345,7 @@ callouts:
             }
         }
         hideFilterDropdown();
+        setTimeout(showEmptyMonthMessages, 60);
     }
 
     function localizeEventDates() {
@@ -392,6 +409,47 @@ callouts:
       }
     }
 
+    function showEmptyMonthMessages() {
+      const monthContainerSelector = '.events--calendar__list-view .solutions-card-grid';
+      const eventsCardMonthWrapperSelector = '.events--calendar__list-view--card-wrapper';
+      const monthContainerElements = document.querySelectorAll(monthContainerSelector);
+      monthContainerElements.forEach(monthContainerElement => {
+        const cardWrapper = monthContainerElement.querySelector(eventsCardMonthWrapperSelector);
+        const eventCardSelector = '.events--calendar--details--card';
+        const eventCardElements = Array.from(cardWrapper?.querySelectorAll?.(eventCardSelector) ?? []);
+        const monthIsEmpty = eventCardElements.every(monthCardElement => {
+          const { clientHeight } = monthCardElement;
+          return clientHeight === 0;
+        });
+        if (monthIsEmpty) {
+          const emptyFilterResultsMessage = monthContainerElement.querySelector('p.events--calendar--empty-filter-results-message');
+          if (emptyFilterResultsMessage) {
+            emptyFilterResultsMessage.style.display = 'block';
+          } else {
+            const emptyFilterResultsMessageTemplate = document.getElementById('empty-filter-results-message');
+            monthContainerElement.appendChild(emptyFilterResultsMessageTemplate.content.cloneNode(true));
+          }
+        } else {
+          const emptyFilterResultsMessage = monthContainerElement.querySelector('p.events--calendar--empty-filter-results-message');
+          if (emptyFilterResultsMessage) {
+            emptyFilterResultsMessage.style.display = 'none';
+          }
+        }
+      });
+    }
+
+    function disableFilterControls() {
+      const categoryFilterDropdownId = 'category-filter-selectorFilter-by-Category';
+      const categoryFilterDropdownElement = document.getElementById(categoryFilterDropdownId);
+      categoryFilterDropdownElement?.setAttribute?.('disabled', '');
+      categoryFilterDropdownElement?.closest?.('.labeled-dropdown')?.classList?.add?.('labeled-dropdown__disabled');
+      const inPersonToggleClass = 'events--calendar--filters--in-person-toggle';
+      const inPersonToggleDisabledClass = `${inPersonToggleClass}__disabled`;
+      const inPersonToggleSelector = `.${inPersonToggleClass}`;
+      const inPersonToggleElement = document.querySelector(inPersonToggleSelector);
+      inPersonToggleElement?.classList?.add?.(inPersonToggleDisabledClass);
+    }
+
     document.querySelector(
         '.events--calendar--filters--category-selector--filter-chips'
     )?.addEventListener?.('click', removeClickedFilterChip);
@@ -407,13 +465,23 @@ callouts:
     document.getElementById('in-person-toggle-button')?.addEventListener?.('click', (e) => {
         const { currentTarget } = e;
         const parent = currentTarget.closest('.events--calendar--filters--in-person-toggle');
+        const disabledClassName = 'events--calendar--filters--in-person-toggle__disabled';
+        if (parent.classList.contains(disabledClassName)) {
+            e.preventDefault();
+            return;
+        }
         parent.classList.toggle('events--calendar--filters--in-person-toggle__toggled-off');
         const calendar = document.querySelector('.events--calendar__list-view');
         calendar?.classList?.toggle?.('events--calendar__list-view__online-only');
+        setTimeout(showEmptyMonthMessages, 60);
     });
 
+    const sortedEventsCount = {{ sorted_events_count }};
     setEventsPageLinksToThisMonthCalendar();
     localizeEventDates();
+    if (sortedEventsCount == 0) {
+      disableFilterControls();
+    }
   });
 </script>
 {% include card-clickability.html 

--- a/events/past.html
+++ b/events/past.html
@@ -67,53 +67,58 @@ callouts:
     {% assign sorted_events = past_events  | sort: "eventdate" | reverse %}
     {% assign current_month = "" %}
     {% assign current_year = "" %}
-    {% for event in sorted_events %}
-      
-      {% assign current_event_date_parts = event.eventdate | split: "-" %}
-      {% if current_event_date_parts[0] != current_year or current_event_date_parts[1] != current_month %}
-        {% assign current_year = current_event_date_parts[0] %}
-        {% assign current_month = current_event_date_parts[1] %}
-        <div class="solutions-card-grid">
-          <h2>{{ event.eventdate | date: "%b %Y"}}</h2>
-          <div class="events--calendar__list-view--card-wrapper">
-      {% endif %}
+    {% assign sorted_events_count = sorted_events | size %}
+    {% if sorted_events_count == 0 %}
+      <p class="events--calendar--no-events-message">No events scheduled at this time.</p>
+    {% else %}
+      {% for event in sorted_events %}
+        
+        {% assign current_event_date_parts = event.eventdate | split: "-" %}
+        {% if current_event_date_parts[0] != current_year or current_event_date_parts[1] != current_month %}
+          {% assign current_year = current_event_date_parts[0] %}
+          {% assign current_month = current_event_date_parts[1] %}
+          <div class="solutions-card-grid">
+            <h2>{{ event.eventdate | date: "%b %Y"}}</h2>
+            <div class="events--calendar__list-view--card-wrapper">
+        {% endif %}
 
-      {% assign category = event.category | default: "community" %}
-      {% assign event_date = event.eventdate | date: "%a, %b %d, %Y" %}
-      {% assign category_card_class = "events--calendar__list-view--event-card__" | append: category %}
-      {% assign online_event_card_class = "events--calendar__list-view--event-card__online" %}
-      {% if event.online %}
-        {% assign category_card_class = category_card_class | append: " " | append: online_event_card_class %}
-      {% endif %}
-      <div class="events--calendar--details--card {{ category_card_class }} solutions-card-grid--card-wrapper--card">
-        <h4 class="events--calendar--body--week--day--event--details--category">
-            {{ category }}
-        </h4>
-        <h3 class="events--calendar--body--week--day--event--details--name">
-            <a href="{{ event.url }}">{{ event.title }}</a>
-        </h3>
-        <h6 class="events--calendar--body--week--day--event--details--date" data-eventdate="{{ event.eventdate }}">
-            {{ event.eventdate | date: "%a %d %b %Y at %I:%M %p %Z" }}
-        </h6>
-        {% if event.excerpt %}
-            {{ event.excerpt }}
+        {% assign category = event.category | default: "community" %}
+        {% assign event_date = event.eventdate | date: "%a, %b %d, %Y" %}
+        {% assign category_card_class = "events--calendar__list-view--event-card__" | append: category %}
+        {% assign online_event_card_class = "events--calendar__list-view--event-card__online" %}
+        {% if event.online %}
+          {% assign category_card_class = category_card_class | append: " " | append: online_event_card_class %}
+        {% endif %}
+        <div class="events--calendar--details--card {{ category_card_class }} solutions-card-grid--card-wrapper--card">
+          <h4 class="events--calendar--body--week--day--event--details--category">
+              {{ category }}
+          </h4>
+          <h3 class="events--calendar--body--week--day--event--details--name">
+              <a href="{{ event.url }}">{{ event.title }}</a>
+          </h3>
+          <h6 class="events--calendar--body--week--day--event--details--date" data-eventdate="{{ event.eventdate }}">
+              {{ event.eventdate | date: "%a %d %b %Y at %I:%M %p %Z" }}
+          </h6>
+          {% if event.excerpt %}
+              {{ event.excerpt }}
+          {% else %}
+              {{ event.content }}
+          {% endif %}
+          <h5 class="events--calendar--body--week--day--event--details--host"><a href="{{ event.url }}">Learn more</a></h5>
+        </div>
+        
+        {% if forloop.last %}
+            </div></div>
         {% else %}
-            {{ event.content }}
+          {% assign peak_ahead_index = forloop.index0 | plus: 1 %}
+          {% assign peak_ahead_date = sorted_events[peak_ahead_index].eventdate %}
+          {% assign peak_ahead_date_parts = peak_ahead_date | split: "-" %}
+          {% if peak_ahead_date_parts[0] != current_event_date_parts[0] or peak_ahead_date_parts[1] != current_event_date_parts[1] %}
+            </div></div>
+          {% endif %}
         {% endif %}
-        <h5 class="events--calendar--body--week--day--event--details--host"><a href="{{ event.url }}">Learn more</a></h5>
-      </div>
-      
-      {% if forloop.last %}
-          </div></div>
-      {% else %}
-        {% assign peak_ahead_index = forloop.index0 | plus: 1 %}
-        {% assign peak_ahead_date = sorted_events[peak_ahead_index].eventdate %}
-        {% assign peak_ahead_date_parts = peak_ahead_date | split: "-" %}
-        {% if peak_ahead_date_parts[0] != current_event_date_parts[0] or peak_ahead_date_parts[1] != current_event_date_parts[1] %}
-          </div></div>
-        {% endif %}
-      {% endif %}
-    {% endfor %}
+      {% endfor %}
+    {% endif %}
   </div>
   <div class="events--calendar--more">
     <div class="conference-speakers--session-speakers--more--link-button">
@@ -143,12 +148,9 @@ callouts:
     </div>
   </div>
 </div>
-
-
 <script type="module">
   document.addEventListener('DOMContentLoaded', () => {
 
-    
     function setEventsBreadcrumbsUrlToThisMonth(calendarViewUrl) {
       const selector = '.full-width-layout--header--breadcrumbs--item > a[href*="/events/calendar/"]';
       const link = document.querySelector(selector);
@@ -160,6 +162,7 @@ callouts:
       const toggleButton = document.querySelector(selector);
       toggleButton?.setAttribute?.('href', calendarViewUrl);
     }
+
     function setCalendarLinkToThisMonth(calendarViewUrl) {
       const attributeName = 'data-eventscalendarlink';
       const attributeSelector = `[${attributeName}="true"]`;
@@ -388,6 +391,7 @@ callouts:
         });
       }
     }
+
     document.querySelector(
         '.events--calendar--filters--category-selector--filter-chips'
     )?.addEventListener?.('click', removeClickedFilterChip);
@@ -407,7 +411,7 @@ callouts:
         const calendar = document.querySelector('.events--calendar__list-view');
         calendar?.classList?.toggle?.('events--calendar__list-view__online-only');
     });
-    
+
     setEventsPageLinksToThisMonthCalendar();
     localizeEventDates();
   });


### PR DESCRIPTION
### Description

- Adds a status message for calendar and list views without any scheduled events.
- Corrects runtime URL determination based on device width for the Community -> Events top navigation menu item.
- Corrects runtime URL determination for the calendar view Events Page View Mode affordance to switch from both the Upcoming Events list view, and the Past Events list view pages.
 
### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
