### PR TITLE
Add OpenSearch Core Triage meeting for 1/31

### DIFF
--- a/_events/2024-0131-opensearch-core-triage.markdown
+++ b/_events/2024-0131-opensearch-core-triage.markdown
@@ -1,0 +1,28 @@
+---
+calendar_date: '2024-01-31'
+eventdate: 2024-01-31 10:00:00 -0600
+
+title: OpenSearch Core Triage - 2024-01-31
+online: true
+signup:
+    url: https://www.meetup.com/opensearch/events/298606132/
+    title: Join on Meetup
+category: community
+---
+
+Join the OpenSearch community to review and triage incoming issues in the OpenSearch repository. Meetings are open-to-all and attendance is encouraged for anyone who hopes to contribute, discuss an issue, or learn more about the project. See Triaging on OpenSearch for more details and FAQs.
+
+### Agenda
+
+1. **Initial Gathering:** Feel free to turn on your video and engage in informal conversation. Shortly, a volunteer triage [facilitator](#what-is-the-role-of-the-facilitator) will begin the meeting and share their screen.
+2. **Record Attendees:** The facilitator will request attendees to share their GitHub profile links. These links will be collected and assembled into a [tag](#how-do-triage-facilitator-tag-comments-during-the-triage-meeting) to annotate comments during the meeting.
+3. **Announcements:** Any announcements will be made at the beginning of the meeting.
+4. **Review of New Issues:** We start by reviewing all untriaged [issues](https://github.com/search?q=label%3Auntriaged+is%3Aopen++repo%3Aopensearch-project%2FOpenSearch+&type=issues&ref=advsearch&s=created&o=desc) for the OpenSearch repo.
+5. **Attendee Requests:** An opportunity for any meeting member to request consideration of an issue or pull request.
+6. **Open Discussion:** Attendees can bring up any topics not already covered by filed issues or pull requests.
+
+### Meeting Links
+
+Join via browser screen share: https://chime.aws/1988437365
+Join via phone (US): +1-929-432-4463,,,1988437365#
+Join via phone (US toll-free): +1-855-552-4463,,,1988437365#


### PR DESCRIPTION
### Description
Adding event for OpenSearch Core Triage meeting for 1/31
 
### Issues Resolved
N/A

### Check List
- [X] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
