### PR TITLE
Remove extra text from end of blog post

### DIFF
--- a/_posts/2023-07-06-optimize-opensearch-index-shard-size.markdown
+++ b/_posts/2023-07-06-optimize-opensearch-index-shard-size.markdown
@@ -106,6 +106,4 @@ Optimizing the number and size of shards in your index can help you get the best
 
 If you prefer to learn about this topic in video format instead of a blog post, check out this YouTube video: [OpenSearch - How to change the number of primary and replica shard(s) of an index](https://www.youtube.com/watch?v=xadv93LlbY4). This blog post is based on this GitHub repository: [OpenSearch_Read_Only_Index](https://github.com/ev2900/OpenSearch_Read_Only_Index)
 
-If you are using Amazon OpenSearch Service (that is, the managed service), the AWS documentation also has information on index shard sizes. The [operational best practices shard strategy](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/bp.html#bp-sharding-strategy) section includes recommendations specific to the AWS managed service.
-
-Backports to our repo 
+If you are using Amazon OpenSearch Service, the AWS documentation also has information on index shard sizes. The [operational best practices shard strategy](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/bp.html#bp-sharding-strategy) section includes recommendations specific to the AWS managed service.


### PR DESCRIPTION
As far as I can tell "Backports to our repo" is just a copy/paste error. Also remove the "the managed service" text as Amazon OpenSearch Service is not the only managed offering of OpenSearch.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
