### PR TITLE
Corrects the Data Prepper version for the recent OpenSearch 2.12.0 release

### DIFF
--- a/_versions/2024-02-20-opensearch-2.12.0.markdown
+++ b/_versions/2024-02-20-opensearch-2.12.0.markdown
@@ -16,7 +16,7 @@ components:
     version: 1.2.0
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.6.1
+    version: data-prepper-2.6.2
     platform_order:
       - docker
       - linux


### PR DESCRIPTION
### Description

The recent OpenSearch 2.12.0 release is linking to Data Prepper 2.6.1. This PR corrects that to 2.6.2.
 
### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
