### PR TITLE
Update HuggingFace link for neural sparse model

### DIFF
--- a/_posts/2023-12-05-improving-document-retrieval-with-sparse-semantic-encoders.md
+++ b/_posts/2023-12-05-improving-document-retrieval-with-sparse-semantic-encoders.md
@@ -465,7 +465,7 @@ The `neural_sparse` query supports two parameters:
 
 ## Selecting a model
 
-OpenSearch provides several pretrained encoder models that you can use out of the box without fine-tuning. For a list of sparse encoding models provided by OpenSearch, see [Sparse encoding models](https://opensearch.org/docs/latest/ml-commons-plugin/pretrained-models/#sparse-encoding-models).
+OpenSearch provides several pretrained encoder models that you can use out of the box without fine-tuning. For a list of sparse encoding models provided by OpenSearch, see [Sparse encoding models](https://opensearch.org/docs/latest/ml-commons-plugin/pretrained-models/#sparse-encoding-models). We have also released the [models](https://huggingface.co/opensearch-project/opensearch-neural-sparse-encoding-v1) in HuggingFace model hub. 
 
 Use the following recommendations to select a sparse encoding model:
 

--- a/_posts/2023-12-05-improving-document-retrieval-with-sparse-semantic-encoders.md
+++ b/_posts/2023-12-05-improving-document-retrieval-with-sparse-semantic-encoders.md
@@ -465,7 +465,7 @@ The `neural_sparse` query supports two parameters:
 
 ## Selecting a model
 
-OpenSearch provides several pretrained encoder models that you can use out of the box without fine-tuning. For a list of sparse encoding models provided by OpenSearch, see [Sparse encoding models](https://opensearch.org/docs/latest/ml-commons-plugin/pretrained-models/#sparse-encoding-models). We have also released the [models](https://huggingface.co/opensearch-project/opensearch-neural-sparse-encoding-v1) in HuggingFace model hub. 
+OpenSearch provides several pretrained encoder models that you can use out of the box without fine-tuning. For a list of sparse encoding models provided by OpenSearch, see [Sparse encoding models](https://opensearch.org/docs/latest/ml-commons-plugin/pretrained-models/#sparse-encoding-models). We have also released the [models](https://huggingface.co/opensearch-project/opensearch-neural-sparse-encoding-v1) in Hugging Face model hub. 
 
 Use the following recommendations to select a sparse encoding model:
 


### PR DESCRIPTION
### Description
In 2.11 we release the neural-sparse search feature, as well as two sparse encoding models. And we have a blog talking about this feature. Recent days we've released the models on HuggingFace model hub, users can play with our sparse_encoding models via HuggingFace and pytorch API. It will be more convinient to conduct search relevance benchmarks, or have a quick try with our models.

To inform users about this, this PR append the model links after the sparse encoding models list.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
