### PR TITLE
Fixes blog posts for dvenable

### DIFF
--- a/_posts/2021-12-15-Introducing-Data-Prepper-1.2.0-with-Log-Pipelines.md
+++ b/_posts/2021-12-15-Introducing-Data-Prepper-1.2.0-with-Log-Pipelines.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Introducing Data Prepper 1.2.0 with Log Pipelines"
 authors:
-- dlv
+- dvenable
 date: 2021-12-15 14:00:00 -0500
 categories:
   - technical-post

--- a/_posts/2022-03-22-Introducing-Data-Prepper-1.3.0-with-New-Aggregation-Processor.md
+++ b/_posts/2022-03-22-Introducing-Data-Prepper-1.3.0-with-New-Aggregation-Processor.md
@@ -4,7 +4,7 @@ title:  "Introducing Data Prepper 1.3.0 with New Aggregation Processor"
 authors:
 - tylgry
 - ddpowers
-- dlv
+- dvenable
 date: 2022-03-21 10:00:00 -0500
 categories:
   - technical-post

--- a/_posts/2022-06-23-S3-Log-Ingestion-Using-Data-Prepper-1.5.0.md
+++ b/_posts/2022-06-23-S3-Log-Ingestion-Using-Data-Prepper-1.5.0.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "S3 log ingestion using Data Prepper 1.5.0"
 authors:
-- dlv
+- dvenable
 date: 2022-06-23 12:00:00 -0500
 categories:
   - technical-post

--- a/_posts/2022-10-10-Announcing-Data-Prepper-2.0.0.md
+++ b/_posts/2022-10-10-Announcing-Data-Prepper-2.0.0.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Announcing Data Prepper 2.0.0"
 authors:
-- dlv
+- dvenable
 - oeyh
 date: 2022-10-10 15:00:00 -0500
 categories:

--- a/_posts/2023-02-07-Announcing-Data-Prepper-2.1.0.md
+++ b/_posts/2023-02-07-Announcing-Data-Prepper-2.1.0.md
@@ -4,7 +4,7 @@ title:  "Announcing Data Prepper 2.1.0"
 authors:
 - kkondaka
 - nsifmoh
-- dlv
+- dvenable
 date: 2023-03-02 14:30:00 -0500
 categories:
   - releases

--- a/_posts/2023-04-19-Announcing-Data-Prepper-2.2.0.md
+++ b/_posts/2023-04-19-Announcing-Data-Prepper-2.2.0.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Announcing Data Prepper 2.2.0"
 authors:
-- dlv
+- dvenable
 date: 2023-04-19 14:30:00 -0500
 categories:
   - releases

--- a/_posts/2023-05-16-Discontinuing-custom-Logstash-distribution.md
+++ b/_posts/2023-05-16-Discontinuing-custom-Logstash-distribution.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Discontinuing the custom Logstash distribution"
 authors:
-- dlv
+- dvenable
 date: 2023-05-16 10:00:00 -0500
 meta_keywords: OpenSearch distribution of Logstash, Apache-licensed Logstash distribution, Logstash plugins for OpenSearch, Logstash distribution
 meta_description: Discover why OpenSearch will discontinue custom Logstash distributions by October 2023 while continuing to provide Logstash plugins for OpenSearch.

--- a/_posts/2023-05-25-Announcing-Data-Prepper-2.3.0.md
+++ b/_posts/2023-05-25-Announcing-Data-Prepper-2.3.0.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Announcing Data Prepper 2.3.0"
 authors:
 - kkondaka
-- dlv
+- dvenable
 date: 2023-06-06 10:00:00 -0700
 categories:
   - releases

--- a/_posts/2023-06-19-End-to-end-acknowledgements-in-Data-Prepper.md
+++ b/_posts/2023-06-19-End-to-end-acknowledgements-in-Data-Prepper.md
@@ -3,7 +3,7 @@ layout: post
 title:  "End-to-end acknowledgments in Data Prepper"
 authors:
 - kkondaka
-- dlv
+- dvenable
 date: 2023-06-19 10:00:00 -0700
 categories:
   - technical-post

--- a/_posts/2023-08-28-Announcing-Data-Prepper-2.4.0.md
+++ b/_posts/2023-08-28-Announcing-Data-Prepper-2.4.0.md
@@ -5,7 +5,7 @@ authors:
 - sudipto
 - kkondaka
 - nsifmoh
-- dlv
+- dvenable
 date: 2023-08-28 11:30:00 -0500
 categories:
   - releases

--- a/_posts/2023-11-27-Announcing-Data-Prepper-2.6.0.md
+++ b/_posts/2023-11-27-Announcing-Data-Prepper-2.6.0.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Announcing Data Prepper 2.6.0"
 authors:
-- dlv
+- dvenable
 date: 2023-11-28 13:30:00 -0600
 categories:
   - releases


### PR DESCRIPTION
### Description

A recent PR (#2612) changed the community member names. In it, my alias `dlv` was changed to `dvenable`, but the the blogs were not updated. This PR updates my previous blogs to use the new alias.
 
### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
