### PR TITLE
Add encoding check workflow to ensure all the files having utf-8 encoding and value continue-on-error

### DIFF
--- a/.github/workflows/encoding-check.yml
+++ b/.github/workflows/encoding-check.yml
@@ -11,7 +11,6 @@ jobs:
     - name: Check for possible file that does not follow utf-8 encoding
       run: |
           set +e
-          wget https://www.w3.org/2001/06/utf-8-wrong/UTF-8-test.html
           IFS=$(echo -en "\n\b")
           COUNTER=0
           for i in `find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.markdown" -o -name "*.html" \) | grep -vE "^./.git"`;

--- a/.github/workflows/encoding-check.yml
+++ b/.github/workflows/encoding-check.yml
@@ -1,0 +1,28 @@
+name: Encoding Checker
+
+on: [pull_request]
+
+jobs:
+  extendedAsciiAndBom:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Check for possible file that does not follow utf-8 encoding
+      run: |
+          set +e
+          wget https://www.w3.org/2001/06/utf-8-wrong/UTF-8-test.html
+          IFS=$(echo -en "\n\b")
+          COUNTER=0
+          for i in `find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.markdown" -o -name "*.html" \) | grep -vE "^./.git"`;
+          do
+              grep -axv '.*' "$i"
+              if [ "$?" -eq 0 ]; then
+                  echo -e "######################\n$i\n######################"
+                  COUNTER=$(( COUNTER + 1 ))
+              fi
+          done
+          if [ "$COUNTER" != 0 ]; then
+              echo "Found files that is not following utf-8 encoding, exit 1"
+              exit 1
+          fi

--- a/.github/workflows/encoding-check.yml
+++ b/.github/workflows/encoding-check.yml
@@ -3,7 +3,7 @@ name: Encoding Checker
 on: [pull_request]
 
 jobs:
-  extendedAsciiAndBom:
+  encoding-checker:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -22,3 +22,4 @@ jobs:
           filter_mode: added
           vale_flags: "--no-exit"
           version: 2.28.0
+        continue-on-error: true


### PR DESCRIPTION

### Description
Add encoding check workflow to ensure all the files having utf-8 encoding and value continue-on-error
 
### Issues Resolved
Closes https://github.com/opensearch-project/project-website/issues/2699
https://github.com/opensearch-project/documentation-website/pull/6722

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
