### PR TITLE
Add truststore and keystore rules to Vale

### DIFF
--- a/.github/vale/styles/OpenSearch/SubstitutionsError.yml
+++ b/.github/vale/styles/OpenSearch/SubstitutionsError.yml
@@ -24,7 +24,7 @@ swap:
   'Huggingface': Hugging Face
   'indices': indexes
   'ingestion pipeline': ingest pipeline
-  'keystore': key store
+  'key store': keystore
   'kmeans': k-means
   'kNN': k-NN
   'machine-learning': machine learning
@@ -45,7 +45,7 @@ swap:
   'time stamp': timestamp
   'timezone': time zone
   'tradeoff': trade-off
-  'truststore': trust store
+  'trust store': truststore
   'U.S.': US
   'web page': webpage
   'web site': website

--- a/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
@@ -135,6 +135,7 @@ tebibyte
 [Tt]ooltip
 [Tt]riage
 [Tt]ranslog
+[Tt]ruststore
 [Uu]nary
 [Uu]ncheck
 [Uu]ncomment


### PR DESCRIPTION
OpenSearch [terms](https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md) are "truststore" and "keystore". Adding those terms and rules to Vale. 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
