### PR TITLE
Add PMC workload dashboard for benchmarks page

### DIFF
--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -73,6 +73,10 @@ benchmark_height_mobile: 6000
 </li>
 
 <li>
+    <a href ="https://{{ page.benchmark_domain }}/app/dashboards#/view/56b9d060-f8f8-11ee-addb-f72c2feaa994?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'PMC%20Nightly%20Dashboard',viewMode:view)&show-time-filter=true&hide-filter-bar=true" target="benchmark-dashboard">PMC</a>
+</li>
+
+<li>
     <a href ="https://{{ page.benchmark_domain }}/app/dashboards?#/view/d67264e0-f5aa-11ed-aff5-859eb6ed880f?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!f,title:'Segment%20Replication%20Benchmark',viewMode:view)&show-time-filter=true&hide-filter-bar=true" target="benchmark-dashboard">Segment Replication</a>
 </li>
 </ul>


### PR DESCRIPTION
### Description
This PR adds opensearch-benchmark's `PMC` workload dashboards to https://opensearch.org/benchmarks page. 
 
### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
