### PR TITLE
Adding conference track badge to macrakis conference speaker profile.

### DIFF
--- a/_community_members/macrakis.md
+++ b/_community_members/macrakis.md
@@ -19,7 +19,13 @@ job_title_and_company: 'The senior technical product manager for OpenSearch'
 personas:
   - conference_speaker
   - author
- 
+  
+conference_id:
+  - "2024-europe"
+  
+session_track:
+  - conference_id: "2024-europe"
+    name: "Search"
 permalink: '/community/members/stavros-macrakis.html'
 redirect_from: '/authors/macrakis/'
 ---


### PR DESCRIPTION
### Description
Adds black circle to macrakis profile to indicate speaker track.  Adds macrakis into global speaker listing. 


### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
