### PR TITLE
Add Big5 workload dashboard to performance page

### DIFF
--- a/benchmarks/index.md
+++ b/benchmarks/index.md
@@ -77,6 +77,10 @@ benchmark_height_mobile: 6000
 </li>
 
 <li>
+    <a href ="https://{{ page.benchmark_domain }}/app/dashboards#/view/c28730f0-1ead-11ef-addb-f72c2feaa994?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:Big5_final,viewMode:view)&show-time-filter=true&hide-filter-bar=true" target="benchmark-dashboard">Big5</a>
+</li>
+
+<li>
    <a href ="https://{{ page.benchmark_domain }}/app/dashboards#/view/1a369150-e232-11ee-addb-f72c2feaa994?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_a=(description:'',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:b4c18ee0-f35f-11ed-aff5-859eb6ed880f,key:query,negate:!f,type:custom,value:'%7B%22bool%22:%7B%22minimum_should_match%22:1,%22should%22:%5B%7B%22match_phrase%22:%7B%22user-tags.cluster-config%22:%22arm64-r6g.2xlarge-3-data-3-shards-1-replica-nmslib-cohere-1m%22%7D%7D,%7B%22match_phrase%22:%7B%22meta.tag_cluster-config%22:%22arm64-r6g.2xlarge-3-data-3-shards-1-replica-nmslib-cohere-1m%22%7D%7D%5D%7D%7D'),query:(bool:(minimum_should_match:1,should:!((match_phrase:(user-tags.cluster-config:arm64-r6g.2xlarge-3-data-3-shards-1-replica-nmslib-cohere-1m)),(match_phrase:(meta.tag_cluster-config:arm64-r6g.2xlarge-3-data-3-shards-1-replica-nmslib-cohere-1m))))))),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!f,title:'%5BVector%20Search%5D%20%5BNmslib%5D%201M%20Cohere%20768D',viewMode:view)&show-time-filter=true&hide-filter-bar=true" target="benchmark-dashboard">Vectorsearch-nmslib-Cohere-1m-768D</a>
 </li>
 


### PR DESCRIPTION
### Description
Add Big5 workload dashboard to [performance page. ](https://opensearch.org/benchmarks). 
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
