### PR TITLE
Correct 2.15.0 meeting time on the go/nogo call

### DIFF
--- a/_events/2024-0625-2-15-release-meetings.markdown
+++ b/_events/2024-0625-2-15-release-meetings.markdown
@@ -1,6 +1,6 @@
 ---
-calendar_date: '2024-06-17'
-eventdate: 2024-06-17 13:00:00 -0700
+calendar_date: '2024-06-21'
+eventdate: 2024-06-21 8:00:00 -0700
 title: OpenSearch 2.15.0 Release Meetings
 online: true
 signup:

--- a/_events/2024-0625-2-15-release-meetings.markdown
+++ b/_events/2024-0625-2-15-release-meetings.markdown
@@ -1,6 +1,6 @@
 ---
 calendar_date: '2024-06-21'
-eventdate: 2024-06-21 8:00:00 -0700
+eventdate: 2024-06-21 08:00:00 -0700
 title: OpenSearch 2.15.0 Release Meetings
 online: true
 signup:

--- a/_events/2024-0625-2-15-release-meetings.markdown
+++ b/_events/2024-0625-2-15-release-meetings.markdown
@@ -25,13 +25,13 @@ On-going release discussions in the [#releases](https://opensearch.slack.com/arc
 
 * Go / No-Go voting
 
-**[Placeholder]June 25th 2024 - 2:00PM PDT**
+**[Placeholder] June 25th 2024 - 2:00PM PDT**
 
 * [Release / Post release](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release) (Release day!) [Release manager, leadership team, Repository owners ]
 
 * Last possible date 06/25/2024 per the [Releases schedule](https://opensearch.org/releases.html).
 
-**[Placeholder]June Pending 2024 - 8AM PDT**
+**[Placeholder] June Pending 2024 - 8AM PDT**
 
 * [Retrospective](https://github.com/opensearch-project/opensearch-build/issues/4786) - Let's do a retro on the 2.15.0 release as a community.
 


### PR DESCRIPTION
### Description
Correct 2.15.0 meeting time on the go/nogo call
 
### Issues Resolved
opensearch-project/opensearch-build#4681

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
