### PR TITLE
head-twitter-metatags.html was causing artifacts to be printed to the…

### DIFF
--- a/_includes/head-blog.html
+++ b/_includes/head-blog.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="ROBOTS" content="ALL" />
     <meta name="MSSmartTagsPreventParsing" content="true" />
-    <meta name="Copyright" content="" />
+
 
     <meta name="keywords" content="
 		{% if page.meta_keywords %} 
@@ -18,10 +18,10 @@
 
     {% if page.meta_description %}<meta name="description" content="{{ page.meta_description }}" />{%endif%}
     
-    {% assign pagetitle = page.title | strip_newlines %}
+    {% assign pagetitle = page.title  | default = "OpenSearch" | strip_newlines %}
 
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="{% if pagetitle != "" %}{{ page.title }}{% else %}OpenSearch{% endif %}" />
+    <meta name="twitter:title" content="{{ page.title }}" />
     {% if page.twittercard.account %}
     <meta name="twitter:site" content="{{ page.twittercard.account }}" />
     {% elsif page.authors %}

--- a/_includes/head-twitter-metatags.html
+++ b/_includes/head-twitter-metatags.html
@@ -84,12 +84,7 @@
 
 
 
-    <!-- TESTING -->
-    <meta name="post category" content="{{ category }}" />
-    <meta name="category image" content="{{ category_image }}" />
-    <meta name="twitter_card_image" content="{{ twitter_card_image }}" />
-    <meta name="keywords" content="{{ meta_keywords }}" />
-    <meta name="description" content="{{ meta_description }}" />
+
    
     
     

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
   <link rel="apple-touch-icon" href="{{'assets/img/apple-touch-icon.png' | relative_url }}">
   <link rel="icon" sizes="192x192" href="{{'assets/img/apple-touch-icon.png' | relative_url }}">
   <link rel="shortcut icon" href="{{'assets/img/favicon.ico' | relative_url }}">
-  <link rel="canonical" href="{%if page.canonical %}{{page.canonical}}{%else%}{{site.url | append: page.url}}{%endif%}" />
+  <link rel="canonical" href="{%if page.canonical %}{{page.canonical}}{%else%}{{site.url | append: page.url}}{%endif%}">
 
   <meta name="msapplication-TileColor" content="#113228">
   <meta name="msapplication-TileImage" content="{{'img/icon-tile.png' | relative_url }}">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,7 +23,7 @@ primary_link_url: /blog
 
     {% include post_import.html %}
     {{ content }}
-    <hr />
+    <hr/>
     {% include share-buttons.html %}
     <div class="blog-nav">
 


### PR DESCRIPTION
# Summary of changes:
This pull request also includes 8 generic images for the most common blog post categories.
I fixed the logic that was rendering the twitter metatags, organized the file, and added additional metatags that I found in the twitter docs.
I removed the twittercard information from head.html, and abstracted it into head-twitter-metatags.html.
I added generic images for the blog post categories into a new _data file (post_categories.yml) and the logic to pull them into the metadata of blog posts.

# File changes:
**_data/post_categories.yml**
Created a new datafile for the post categories. In this data file, links to generic images have been added.
Added a commented out path for local testing one of the images. Normally - The pathing is not correct for local, only for the live site. So this is to help with debugging in the future.

**_includes/head-twitter-metatags.htmll**
Abstracted the twitter metadata into this new .html file.
these metatags use the category of the blog post to determine the generic image to use for the twittercard.
And if there is a featured image already on the blog post, the featured image is used instead of the generic.

**_includes/head.htmll**
removed twittercard metadata from head.html. All of this is now in head-twitter-metatags.html.

**_layouts/default.htmll**
Added logic to use either head.html or head-twitter-metatags.html depending on the page type. If it is a blog post, it uses head-twitter-metatags.html, otherwise it uses head.html.

Issues Resolved
- #1169 

