### PR TITLE
Fix formatting issue of the table in fp16 blog

### DIFF
--- a/_posts/2024-06-19-optimizing-opensearch-with-fp16-quantization.md
+++ b/_posts/2024-06-19-optimizing-opensearch-with-fp16-quantization.md
@@ -193,14 +193,16 @@ To compare performance metrics and memory savings, we ran tests on the large-sca
 |Force merge segments	|1	|1	|
 |Client instance	|r5.16xlarge	|r5.16xlarge	|
 
-Config ID	|Optimization strategy	|m	|ef_construction	|ef_search	|
-|---	|---	|---	|---	|---	|
-|hnsw1	|Default configuration	|16	|100	|100	|
-|hnsw2	|Balance between latency, memory, and recall	|16	|128	|128	|
-|hnsw3	|Optimize for recall	|16	|256	|256	|
 
-Faiss HNSW SQfp16 requires 4 data nodes---half the number needed for Faiss HNSW (8). This demonstrates that SQfp16 reduces memory requirements by 50%. 
+Faiss HNSW SQfp16 requires 4 data nodes---half the number needed for Faiss HNSW (8). This demonstrates that SQfp16 reduces memory requirements by 50%.
 For more information about estimating the required memory and number of data nodes, see the [Appendix](#appendix-memory-and-data-node-requirement-estimation).
+
+
+| Config ID	 |Optimization strategy	|m	|ef_construction	|ef_search	|
+|------------|---	|---	|---	|---	|
+| hnsw1	     |Default configuration	|16	|100	|100	|
+| hnsw2	     |Balance between latency, memory, and recall	|16	|128	|128	|
+| hnsw3	     |Optimize for recall	|16	|256	|256	|
 
 #### Recall and memory results
 


### PR DESCRIPTION
### Description
Fix formatting issue of the table in fp16 blog and move the text in between those 2 tables to avoid squashing of those 2 tables.
 
![image](https://github.com/opensearch-project/project-website/assets/89161683/56218c2c-97b1-4d95-96b6-6bfeff4f1cb6)

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
