### PR TITLE
CfP for OpenSearchCon 2024 North America is now *closed*.

### DIFF
--- a/events/opensearchcon/2024/north-america/cfp.md
+++ b/events/opensearchcon/2024/north-america/cfp.md
@@ -38,6 +38,8 @@ permalink: /events/opensearchcon/2024/north-america/cfp.html
 ---
 ![CFP Banner](/assets/media/opensearchcon/2024/OSC2024_NASF_Social-Graphic2_1200x627.png){: width="100%" }
 
+The CfP for OpenSearchCon 2024 North America is now *closed*.
+
 
 This year’s conference dedicates four tracks to topics the OpenSearch community cares about. We invite the community to submit your best ideas and join us for a great conference in San Francisco.
 
@@ -70,7 +72,7 @@ This information will help the reviewers to get a good impression of your sessio
 
 ## When does it close
 
-CfP ends June 28, 2024 at 11:59pm EST
+CfP ends June 28, 2024 at 11:59pm EST. It is now closed. 
 
 ## Unconference
 
@@ -81,5 +83,7 @@ Based on the success and excitement of the Unconference we held at OpenSearchCon
 
 It is expected that your submission and presentation follow the [OpenSearch Code of Conduct](https://opensearch.org/codeofconduct.html).
 
-<iframe class="airtable-embed" src="https://airtable.com/embed/appWltifOss0C1Ze3/paghymzSgP6jpreTz/form" frameborder="0" onmousewheel="" width="100%" height="1500" style="background: transparent; border: 1px solid #ccc;"></iframe>
+The CFP for OpenSearchCon 2024 North America is now *closed*.
+
+
 

--- a/events/opensearchcon/2024/north-america/index.md
+++ b/events/opensearchcon/2024/north-america/index.md
@@ -67,13 +67,7 @@ Join us  September 24 through  September 26, 2024 at the [Hilton Union Square in
 </div>
 What makes the community want to attend OpenSearchCon? Beyond the opportunity to network with peers and commune with passionate open sourcers, OpenSearchCon is where you come to hear compelling stories, learn differentiated use cases, and gain educational insights shared by our community. If you have a story to tell or an idea you’d like to present to the community, our Call for Presentations (CfP) for OpenSearchCon North America is now open—go [here](/events/opensearchcon/2024/north-america/cfp.html) and submit by June 28, 2024 at 11:59pm EST to submit your abstract.
 
-<div class="redesign-button-pair--wrapper">
-            <div class="redesign-button--wrapper redesign-button--wrapper__text-only__dark">
-                <a href="/events/opensearchcon/2024/north-america/cfp.html" class="redesign-button--anchor">
-                    Submit a Presentation
-                </a>
-            </div>
-</div>
+The CfP for OpenSearchCon 2024 North America is now *closed*.
 
 
 ### Book your hotel for OpenSearchCon


### PR DESCRIPTION
### Description
Indicates closure of CfP for OSCON 2024 NA and removes form.
 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
