### PR TITLE
BUG -- new issue Project-assigning is not working. 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -2,7 +2,7 @@ name: 🐛 Bug report
 description: Create a report to help us improve
 title: "[BUG] <title>"
 labels: ['bug, untriaged']
-projects: ["Website Update Project"]
+projects: ["opensearch-project/Website Update Project"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: 🎆 Feature request
 description: Suggest an idea for this project
 title: '[Feature Request] <title>'
 labels: ['enhancement, untriaged']
-projects: ["Website Update Project"]
+projects: ["opensearch-project/74"]
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
we need to have the repo name and also the project name in order for the new issues to be assigned automatically to this project. In the github documentation, they show the numeric project numbers being used. The number "74" which is used in the feature-request template represents the "website update project".

The syntax are different between these two issues so that we can see if either will work.

Note: there are disclaimers saying that the person submitting the new-issue must have write-access to the repo for this auto-assign to the project to work. If neither of these work, likely we will have to scrap it and rely on github-workflows-autoassignissue if we want to implement this feature.


### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
