### PR TITLE
Remove Point in Time from Vale vocabulary

### DIFF
--- a/.github/vale/styles/Vocab/OpenSearch/Products/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Products/accept.txt
@@ -124,7 +124,6 @@ Painless
 Peer Forwarder
 Performance Analyzer
 Piped Processing Language
-Point in Time
 Powershell
 Pureinsights
 Python


### PR DESCRIPTION
Remove Point in Time from Vale vocabulary so the phrase "point in time" is not flagged.

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
