### PR TITLE
Adds new platform for download page, "Arch Linux" and the necessary i…

### DIFF
--- a/_artifacts/opensearch-2.15/x64/opensearch-2.15.0-archlinux-x64.markdown
+++ b/_artifacts/opensearch-2.15/x64/opensearch-2.15.0-archlinux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 2.15.0
+platform: archlinux
+architecture: x64
+slug: opensearch-2.15.0-archlinux-x64
+category: opensearch
+type: system-package
+archlinux_package_name: opensearch
+link: https://www.freshports.org/textproc/opensearch
+---

--- a/_artifacts/opensearch-2.15/x64/opensearch-2.15.0-archlinux-x64.markdown
+++ b/_artifacts/opensearch-2.15/x64/opensearch-2.15.0-archlinux-x64.markdown
@@ -8,5 +8,5 @@ slug: opensearch-2.15.0-archlinux-x64
 category: opensearch
 type: system-package
 archlinux_package_name: opensearch
-link: https://www.freshports.org/textproc/opensearch
+link: https://archlinux.org/packages/extra/x86_64/opensearch/
 ---

--- a/_artifacts/opensearch-2.15/x64/opensearch-dashboards-2.15.0-archlinux-x64.markdown
+++ b/_artifacts/opensearch-2.15/x64/opensearch-dashboards-2.15.0-archlinux-x64.markdown
@@ -9,5 +9,5 @@ category: opensearch-dashboards
 slug: opensearch-dashboards-2.15.0-archlinux-x64
 version: 2.15.0
 archlinux_package_name: opensearch-dashboards
-link: https://www.freshports.org/textproc/opensearch-dashboards
+link: https://archlinux.org/packages/extra/x86_64/opensearch-dashboards/
 ---

--- a/_artifacts/opensearch-2.15/x64/opensearch-dashboards-2.15.0-archlinux-x64.markdown
+++ b/_artifacts/opensearch-2.15/x64/opensearch-dashboards-2.15.0-archlinux-x64.markdown
@@ -1,0 +1,13 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: archlinux
+type: system-package
+category: opensearch-dashboards
+slug: opensearch-dashboards-2.15.0-archlinux-x64
+version: 2.15.0
+archlinux_package_name: opensearch-dashboards
+link: https://www.freshports.org/textproc/opensearch-dashboards
+---

--- a/_layouts/versions.html
+++ b/_layouts/versions.html
@@ -27,6 +27,7 @@ pretty:
     macos: macOS
     java: "Java"
     docker: Docker
+    archlinux: "Arch Linux"
   extensions:
     targz: ".tar.gz"
     exe: "Installer (exe)"
@@ -60,6 +61,7 @@ platform_order:
   - linux
   - docker
   - freebsd
+  - archlinux
   - macos
   - windows
   - java
@@ -210,6 +212,13 @@ this is the built-in error checking for the version definition having missing ar
                 <pre># pkg install {{details.freebsd_package_name}}</pre>
                 </div>{% endcapture %}
               {% assign artifact_extras = artifact_extras | append: artifact_extra %}
+            {% endif %}
+            {% if details.archlinux_package_name %}
+            {% capture artifact_extra %}<div class="extra_links extra_{{artifact_id}}">
+            <p>Install from Arch Linux packages:</p>
+            <pre># pacman -S install {{details.archlinux_package_name}}</pre>
+            </div>{% endcapture %}
+            {% assign artifact_extras = artifact_extras | append: artifact_extra %}
             {% endif %}
             {% if details.link %}
               {% capture artifact_extra %}<div class="extra_links extra_{{artifact_id}}">


### PR DESCRIPTION
…nstructions to install via its native package manager.

### Description

#642 has been sitting around for a while. I was under the impression that there was some kind of clarification that was to be added to the download instructions regarding how the `opensearch` package is actually `opensearch-min`, but I think it's sat long enough. Here's the path I took: 

I added a dropdown to the OpenSearch and OpenSearch Dashboards sections of the download page to inlcude "Arch Linux" as a platform. Selecting any of the build variants will just show the command line instruction to install the `opensearch` package via `pacman` (`pacman -S opensearch`) 

Caveats: 
* The pacman package listing showed the only available architecture was x86_64, so I left out any other arch. 
* I didn't see pacman packages for the earlier release line of 1.3.x so I created no download artifacts for those. 


 
### Issues Resolved
#642 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
