### PR TITLE
Add highlighting to inline code font

### DIFF
--- a/_sass/_opensearch.scss
+++ b/_sass/_opensearch.scss
@@ -503,4 +503,20 @@
     img {
         @extend .img__outlined;
     }
+
+    .highlight pre, .highlight code {
+        border: none;
+    }
+    pre code {
+        padding: 0;
+    }
+    code {
+        font-size: 0.9rem;
+        padding: 2px 4px;
+        border-radius: 4px;
+        border: 1px solid #EAEAEA;
+    }
+    code, .highlight {
+        background-color: $background-darker;
+    }
 }


### PR DESCRIPTION
This PR adds highlighting to the items in inline code font. Also, it removes the inner border from the code blocks and makes all font the same size. See an example image:

![Screenshot 2024-07-29 at 4 23 51 PM](https://github.com/user-attachments/assets/1c872326-32ee-4a79-ad96-c95f9f250052)

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
