### PR TITLE
[Fix] fix wrong figure url in blog

### DIFF
--- a/_posts/2024-06-11-A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12.md
+++ b/_posts/2024-06-11-A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12.md
@@ -101,7 +101,7 @@ The following figure shows the experiment results for 1M documents.
 
 The following figure shows the experiment results for 8.8M documents.
 
-<img src="/assets/media/blog-images/2024-06-11-A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12/experiments-on-1m.png"/>
+<img src="/assets/media/blog-images/2024-06-11-A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12/experiments-on-8m.png"/>
 
 ### Results explained
 


### PR DESCRIPTION
### Description
In blog `2024-06-11-A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12.md` there is a wrong figure url in section `Accelerating sparse search with Lucene upgrades`. We used a duplicate link in 2 subsections. This PR fix the wrong link.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
