### PR TITLE
Arch Linux install command.

### DIFF
--- a/_layouts/versions.html
+++ b/_layouts/versions.html
@@ -223,7 +223,7 @@ this is the built-in error checking for the version definition having missing ar
             {% if details.archlinux_package_name %}
             {% capture artifact_extra %}<div class="extra_links extra_{{artifact_id}}">
             <p>Install from Arch Linux packages:</p>
-            <pre># pacman -S install {{details.archlinux_package_name}}</pre>
+            <pre># pacman -S {{details.archlinux_package_name}}</pre>
             </div>{% endcapture %}
             {% assign artifact_extras = artifact_extras | append: artifact_extra %}
             {% endif %}


### PR DESCRIPTION
### Description
Fixes Arch Linux install command. 
 
Replaces #3126 to avoid DCO.


### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
