### PR TITLE
One more Register Now button for OpenSearchCon NA

### DIFF
--- a/events/opensearchcon/2024/north-america/index.md
+++ b/events/opensearchcon/2024/north-america/index.md
@@ -56,6 +56,14 @@ related_articles:
 ### **Join us in San Francisco, September 24-26, 2024 for OpenSearchCon North America!**
 ![](/assets/media/opensearchcon/2024/OSC2024_NASF_Web-banner_1440x360.png ){: width="100%" }
 
+<div class="redesign-button-pair--wrapper">
+            <div class="redesign-button--wrapper redesign-button--wrapper__text-only__dark">
+                <a href="/events/opensearchcon/2024/north-america/register.html" class="redesign-button--anchor">
+                    Register Now
+                </a>
+            </div>
+</div>
+
 The OpenSearch user community continues to expand with new contributors, maintainers, organizations, and partners who are dedicated to make the project a success. It’s all of you who make OpenSearchCon the place where the open source community comes together. That’s why we’re delighted to host the third OpenSearchCon North America, this year in San Francisco!
 
 Join us  September 24 through  September 26, 2024 at the [Hilton Union Square in San Francisco](https://www.hilton.com/en/hotels/sfofhhh-hilton-san-francisco-union-square/) for OpenSearchCon North America 2024:


### PR DESCRIPTION
### Description
Adds another prominent button to the landing page for OpenSearchCon North America 2024 to the registration page. 
CFP is closed - omitting the button. 
 
### Issues Resolved
#2886 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
