### PR TITLE
[2.16.0 Release] Update the calendar date for 2.16.0 retro meeting

### DIFF
--- a/_events/2024-0806-2-16-release-meetings.markdown
+++ b/_events/2024-0806-2-16-release-meetings.markdown
@@ -1,5 +1,5 @@
 ---
-calendar_date: '2024-08-07'
+calendar_date: '2024-08-13'
 eventdate: 2024-08-13 09:00:00 -0700
 title: OpenSearch 2.16.0 Release Meetings
 online: true


### PR DESCRIPTION
### Description
[2.16.0 Release] Update the calendar date for 2.16.0 retro meeting
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4771 and https://github.com/opensearch-project/opensearch-build/issues/4847

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
