### PR TITLE
Bug fixes - fixed meta_descriptions for our pages as well as partner images in the opensearch con "Exhibitions" directory 

### DIFF
--- a/_includes/head-twitter-metatags.html
+++ b/_includes/head-twitter-metatags.html
@@ -1,7 +1,7 @@
 
 
 {% assign meta_keywords = page.meta_keywords | default: "open-source, search, opensearch" %}
-{% assign meta_description = page.excerpt  | default:page.description | default:page.meta_description  | default: "OpenSearch is a community-driven, Apache 2.0-licensed open source search and analytics suite that makes it easy to ingest, search, visualize, and analyze data." %}
+{% assign meta_description = page.meta_description  | default:page.description | default: "OpenSearch is a community-driven, Apache 2.0-licensed open source search and analytics suite that makes it easy to ingest, search, visualize, and analyze data." %}
 {% assign twitter_card_type = "summary_large_image" %}
 {% assign twitter_card_title = page.title  | default: "OpenSearch"%}
 {% assign OpenSearch_twitter_account = "@OpenSearchProj" %}
@@ -45,6 +45,7 @@
 <meta name="msapplication-TileColor" content="#113228">
 <meta name="msapplication-TileImage" content="{{'img/icon-tile.png' | relative_url }}"> 
 <meta name="meta_keywords" content="{{ meta_keywords  | xml_escape }}" />
+<meta name="description" content="{{ meta_description  | xml_escape }}" />
 <meta name="meta_description" content="{{ meta_description  | xml_escape }}" />
 
 <!-- TWITTER -->

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-calyptia.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-calyptia.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Calyptia
-logo: '/assets/media/partners/calyptia.png'
+logo: '/assets/media/partners/calyptia/calyptia.png'
 link: '/partners/calyptia.html'
 ---

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-eliatra.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-eliatra.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Eliatra
-logo: '/assets/media/partners/eliatra.png'
+logo: '/assets/media/partners/eliatra/eliatra.png'
 link: '/partners/eliatra.html'
 ---

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-instaclustr.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-instaclustr.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Instaclustr
-logo: '/assets/media/partners/instaclustr.png'
+logo: '/assets/media/partners/instaclustr/instaclustr.png'
 link: '/partners/instaclustr.html'
 ---

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-major-league-hacking.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-major-league-hacking.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Major League Hacking
-logo: '/assets/media/partners/major-league-hacking.png'
+logo: '/assets/media/partners/major_league_hacking/major-league-hacking.png'
 link: 'https://mlh.io/'
 ---

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-pureinsights.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-pureinsights.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Pureinsights
-logo: '/assets/media/partners/pureinsights.png'
+logo: '/assets/media/partners/pureinsights/pureinsights.png'
 link: '/partners/pureinsights.html'
 ---

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-searchblox.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-searchblox.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Searchblox
-logo: '/assets/media/partners/searchblox.png'
+logo: '/assets/media/partners/searchblox/searchblox.png'
 link: '/partners/searchblox.html'
 ---

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-searchiumai.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-searchiumai.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Searchium.AI
-logo: '/assets/media/partners/searchiumai.png'
+logo: '/assets/media/partners/searchiumai/searchiumai.png'
 link: '/partners/searchiumai.html'
 ---

--- a/_opensearchcon_exhibitors/2022/north-america/2022-north-america-titaniam.md
+++ b/_opensearchcon_exhibitors/2022/north-america/2022-north-america-titaniam.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2022-north-america'
 name: Titaniam
-logo: '/assets/media/partners/titaniam.png'
+logo: '/assets/media/partners/portal26/portal26-exhibitor-logo.png'
 link: 'https://www.titaniamlabs.com/'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-aiven.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-aiven.md
@@ -1,7 +1,7 @@
 ---
 conference_id: '2023-north-america'
 name: Aiven
-logo: '/assets/media/partners/aiven.png'
+logo: '/assets/media/partners/aiven/aiven.png'
 link: '/partners/aiven.html'
 ---
 

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-bigdata-boutique.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-bigdata-boutique.md
@@ -1,7 +1,7 @@
 ---
 conference_id: '2023-north-america'
 name: BigData Boutique
-logo: '/assets/media/partners/bigdataboutique.png'
+logo: '/assets/media/partners/bigdataboutique/bigdataboutique.png'
 link: '/partners/bigdataboutique.html'
 ---
 

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-bonsai.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-bonsai.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Bonsai
-logo: '/assets/media/partners/bonsai.png'
+logo: '/assets/media/partners/bonsai/bonsai.png'
 link: '/partners/bonsai.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-calyptia.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-calyptia.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Calyptia
-logo: '/assets/media/partners/calyptia.png'
+logo: '/assets/media/partners/calyptia/calyptia.png'
 link: '/partners/calyptia.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-canonical.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-canonical.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Canonical | Ubuntu
-logo: '/assets/media/partners/canonical.png'
+logo: '/assets/media/partners/canonical/canonical.png'
 link: '/partners/canonical.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-coralogix.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-coralogix.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Coralogix
-logo: '/assets/media/partners/coralogix.png'
+logo: '/assets/media/partners/coralogix/coralogix.png'
 link: '/partners/coralogix.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-elastiflow.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-elastiflow.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: ElastiFlow
-logo: '/assets/media/partners/elastiflow.png'
+logo: '/assets/media/partners/elastiflow/elastiflow.png'
 link: '/partners/elastiflow.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-eliatra.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-eliatra.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023north-america'
 name: Eliatra
-logo: '/assets/media/partners/eliatra.png'
+logo: '/assets/media/partners/eliatra/eliatra.png'
 link: '/partners/eliatra.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-graylog.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-graylog.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Graylog
-logo: '/assets/media/partners/graylog.png'
+logo: '/assets/media/partners/graylog/graylog.png'
 link: '/partners/graylog.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-gsi-technology.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-gsi-technology.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: GSI Technology
-logo: '/assets/media/partners/just-gsi-logo.png'
+logo: '/assets/media/partners/gsi-technology/just-gsi-logo.png'
 link: '/partners/gsi-technology.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-instaclustr.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-instaclustr.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Instaclustr
-logo: '/assets/media/partners/instaclustr.png'
+logo: '/assets/media/partners/instaclustr/instaclustr.png'
 link: '/partners/instaclustr.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-ironcorelabs.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-ironcorelabs.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: IronCore Labs, Inc.
-logo: "/assets/media/partners/ironcore-labs-logo.png"
+logo: "/assets/media/partners/ironcorelabs/ironcore-labs-logo.png"
 link: "https://ironcorelabs.com"
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-kmwtechnology.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-kmwtechnology.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: KMW Technology
-logo: '/assets/media/partners/kmw-technology.png'
+logo: '/assets/media/partners/kmw/kmw-technology.png'
 link: https://www.kmwllc.com/
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-mach5.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-mach5.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Mach5 Software, Inc.
-logo: '/assets/media/partners/mach5-logo.png'
+logo: '/assets/media/partners/mach5/mach5-logo.png'
 link: 'https://mach5.io/'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-opensearch-managed-service.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-opensearch-managed-service.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: OpenSearch Managed Service
-logo: '/assets/media/partners/aws.png'
+logo: '/assets/media/partners/aws/aws.png'
 link: 'https://aws.amazon.com/opensearch-service/'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-opensourceconnections.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-opensourceconnections.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: OpenSource Connections
-logo: '/assets/media/partners/osc-logomark-color.png'
+logo: '/assets/media/partners/opensource-connections/opensource-connections-logo.png'
 link: '/partners/opensourceconnections.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-pureinsights.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-pureinsights.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Pureinsights
-logo: '/assets/media/partners/pureinsights.png'
+logo: '/assets/media/partners/pureinsights/pureinsights.png'
 link: '/partners/pureinsights.html'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-smartsearch.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-smartsearch.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Smart Search Tools
-logo: '/assets/media/partners/smartsearch.png'
+logo: '/assets/media/partners/smartsearch/smartsearch.png'
 link: 'https://smartsearchtools.com'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-snappyflow.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-snappyflow.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: SnappyFlow
-logo: '/assets/media/partners/snappyflow.png'
+logo: '/assets/media/partners/snappyflow/snappyflow.png'
 link: 'https://www.snappyflow.io/'
 ---

--- a/_opensearchcon_exhibitors/2023/north-america/2023-north-america-titaniam.md
+++ b/_opensearchcon_exhibitors/2023/north-america/2023-north-america-titaniam.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2023-north-america'
 name: Titaniam
-logo: '/assets/media/partners/titaniam.png'
+logo: '/assets/media/partners/portal26/portal26-logo-large.png'
 link: 'https://www.titaniamlabs.com/'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-aiven.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-aiven.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: Aiven
-logo: '/assets/media/partners/aiven.png'
+logo: '/assets/media/partners/aiven/aiven.png'
 link: 'https://aiven.io'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-bitergia.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-bitergia.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: Bitergia
-logo: '/assets/media/partners/bitergia.png'
+logo: '/assets/media/partners/bitergia/bitergia.png'
 link: 'https://bitergia.com'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-elastiflow.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-elastiflow.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: ElastiFlow
-logo: '/assets/media/partners/elastiflow.png'
+logo: '/assets/media/partners/elastiflow/elastiflow.png'
 link: 'https://www.elastiflow.com'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-eliatra.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-eliatra.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: Eliatra
-logo: '/assets/media/partners/eliatra.png'
+logo: '/assets/media/partners/eliatra/eliatra.png'
 link: 'https://eliatra.com'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-hyland.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-hyland.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: Hyland
-logo: '/assets/media/partners/hyland.jpg'
+logo: '/assets/media/partners/hyland/hyland.jpg'
 link: 'https://hyland.com'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-infinio.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-infinio.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: Infinio
-logo: '/assets/media/partners/infino.png'
+logo: '/assets/media/partners/infino/infino.png'
 link: 'https://infino.ai'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-opensourceconnections.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-opensourceconnections.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: OpenSource Connections
-logo: '/assets/media/partners/osc-logomark-color.png'
+logo: '/assets/media/partners/opensource-connections/opensource-connections-logo.png'
 link: 'https://www.opensourceconnections.com'
 ---

--- a/_opensearchcon_exhibitors/2024/europe/2024-europe-quesma.md
+++ b/_opensearchcon_exhibitors/2024/europe/2024-europe-quesma.md
@@ -1,6 +1,6 @@
 ---
 conference_id: '2024-europe'
 name: Quesma
-logo: '/assets/media/partners/quesma.png'
+logo: '/assets/media/partners/quesma/quesma.png'
 link: 'https://quesma.com'
 ---


### PR DESCRIPTION
### Description
Meta_description was defaulting to the page excerpt for every page, instead of the meta descriptions that we have been creating.

Additionally, I created the meta tag "description" which is what google uses to display additional info in the context of its search results - it does not use "meta_description" it uses "description".
Read more here... https://developers.google.com/search/docs/appearance/snippet
 
 
 And then the partner images had broken file paths. Fixed now. 


### Issues Resolved
#3171 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
