### PR TITLE
Add performance metrics to Vale

### DIFF
--- a/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
@@ -82,6 +82,7 @@ Levenshtein
 [Mm]ultiword
 [Nn]amespace
 [Oo]nboarding
+p\d{2}
 pebibyte
 [Pp]laintext
 [Pp]luggable


### PR DESCRIPTION
Make Vale accept performance metrics notation like p90.

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
