### PR TITLE
OSCON schedule and navbar update. 

### DIFF
--- a/_data/top_nav.yml
+++ b/_data/top_nav.yml
@@ -78,3 +78,5 @@ items:
         url: https://playground.opensearch.org/
       - label: Performance Benchmarks
         url: /benchmarks/
+      - label: Release Metrics
+        url: /release-metrics/

--- a/_data/top_nav.yml
+++ b/_data/top_nav.yml
@@ -1,25 +1,14 @@
 items:
   - label: OpenSearchCon
     children:
-      - label: 2024 Europe
-        url: /events/opensearchcon/2024/europe/index.html
       - label: 2024 North America
         url: /events/opensearchcon/2024/north-america/index.html
-#        children:
-#          - label: Speakers
-#            url: /events/opensearchcon/2024/north-america/speakers/index.html
-#          - label: Sessions
-#            url: /events/opensearchcon/2024/north-america/sessions/index.html
-#          - label: Exhibitors
-#            url: /events/opensearchcon/2024/north-america/exhibitors/index.html
-#          - label: Workshops
-#            url: /events/opensearchcon/2024/north-america/workshops/index.html
-#          - label: Unconference
-#            url: /events/opensearchcon/2024/north-america/unconference/index.html
-      - label: 2024 India
-        url: /events/opensearchcon/2024/india/index.html
       - label: Archive
         children:
+          - label: 2024 India
+            url: /events/opensearchcon/2024/india/index.html
+          - label: 2024 Europe
+            url: /events/opensearchcon/2024/europe/index.html
           - label: 2023 North America
             url: /events/opensearchcon/2023/north-america/index.html
           - label: 2022 North America

--- a/events/opensearchcon/2024/north-america/index.md
+++ b/events/opensearchcon/2024/north-america/index.md
@@ -102,6 +102,124 @@ We have watched OpenSearchCon North America grow from its humble beginnings as a
 We hope to see  you in San Francisco!
 
 
+### Day 1 - Tuesday, September 24, 2024 
+
+Opening day will have our main keynote speech, two session rooms running, and a couple of special events, including an evening reception with appetizers and beer/wine.
+
+
+<table class="oscon2024-north-america" style="border: 1px solid black; width: 100%" width="100%">
+<tr>
+    <td>7:00am-8:50am</td>
+    <td>Continental breakfast - Golden Gate Ballroom</td>
+</tr>
+<tr>
+    <td>7:00am-5:00pm</td>
+    <td>Registration open - Golden Gate Ballroom Foyer</td>
+</tr>
+<tr>
+    <td>7:00am-5:00pm</td>
+    <td>Exhibitor setup - East Foyer Lounge</td>
+</tr>
+<tr>
+    <td>9:00am-9:50am</td>
+    <td>Opening keynote by Eli Fisher - Main Stage/Continental Rooms 4-5
+</td>
+</tr>
+<tr>
+    <td>10:00am-5:30pm</td>
+    <td>Attendee Lounge - Continental 6
+</td>
+</tr>
+<tr>
+    <td>10:00am-12:00pm</td>
+    <td>Partner round table - Continental Rooms 7-9
+</td>
+</tr>
+<tr>
+    <td>10:00am-12:00pm</td>
+    <td>General sessions - Continental Rooms 1-3
+</td>
+</tr>
+<tr>
+    <td>12:00pm-12:55pm</td>
+    <td>Hosted Lunch - Golden Gate Ballroom</td>
+</tr>
+<tr>
+    <td>1:00pm-4:00pm</td>
+    <td>The Unconference</td>
+</tr>
+<tr>
+    <td>1:00pm-5:30pm</td>
+    <td>General sessions - Continental Rooms 1-3
+</td>
+</tr>
+</table>
+
+
+### Day 2 - Wednesday, September 25
+
+The main session day of the conference. Sessions will be running in three rooms, all day, right up to the Search Party starting at 5:30pm.
+
+
+<table class="oscon2024-europe" style="border: 1px solid black; width: 100%" width="100%">
+<tr>
+    <td>7:00am-8:50am</td>
+    <td>Continental breakfast - Golden Gate Ballroom</td>
+</tr>
+<tr>
+    <td>7:00am-5:30pm</td>
+    <td>Registration open - Golden Gate Ballroom Foyer</td>
+</tr>
+<tr>
+    <td>9:00am-5:30pm</td>
+    <td>Exhibitor area open - East Foyer Lounge
+</td>
+</tr>
+<tr>
+    <td>9:00am-9:10am</td>
+    <td>Opening remarks - Main Stage/Continental Rooms 4-5</td>
+</tr>
+<tr>
+    <td>9:15am-5:30pm</td>
+    <td>Attendee Lounge - Continental Room 6</td>
+</tr>
+<tr>
+    <td>9:15am-12:00pm</td>
+    <td>Main stage sessions - Continental Rooms 4-5</td>
+</tr>
+<tr>
+    <td>9:15am-12:00pm</td>
+    <td>General sessions - Continental Rooms 1-3</td>
+</tr>
+<tr>
+    <td>9:15am-12:00pm</td>
+    <td>General sessions - Continental Rooms 7-9</td>
+</tr>
+<tr>
+    <td>12:00pm-12:55pm</td>
+    <td>Hosted Lunch - Golden Gate Ballroom</td>
+</tr>
+<tr><td>1:00pm-5:30pm</td><td> Main stage sessions - Continental Rooms 4-5 </td></tr>
+<tr><td>1:00pm-5:30pm</td><td> General sessions - Continental Rooms 1-3</td></tr>
+<tr><td>1:00pm-5:30pm</td><td> General sessions - Continental Rooms 7-9</td></tr>
+<tr><td>5:30pm-7:00pm</td><td> The search party! - East Foyer Lounge</td></tr>
+
+</table>
+
+### Day 3 - Thursday, September 26
+
+Day three is dedicated to training, workshops, and a capture the flag (CTF awards ceremony at 4pm)
+
+<table class="oscon2024-europe" style="border: 1px solid black; width: 100%" width="100%">
+<tr><td>7:00am-8:50am</td><td>Continental breakfast - Continental Room 4</td></tr>
+<tr><td>7:00am-9:00am</td><td>Registration open - East Foyer Lounge</td></tr>
+<tr><td>8:00am-12:00pm</td><td>Search training - Continental Rooms 1 & 3</td></tr>
+<tr><td>9:00am-12:00pm</td> <td>OpenSearch workshop - Continental Room 2</td></tr>
+<tr><td>10:00am-12:00pm</td><td>Capture the Flag sponsored by Graylog - Continental Room 4</td></tr>
+<tr><td>12:00pm-12:55pm</td><td>Hosted Lunch - Continental Room 4</td></tr>
+<tr><td>1:00pm-5:00pm</td><td>Search training - Continental Rooms 1 & 3</td></tr>
+<tr><td>1:00pm-4:30pm</td><td>Capture the Flag sponsored by Graylog - Continental Room 4</td></tr>
+</table>
 
 
 

--- a/events/opensearchcon/2024/north-america/index.md
+++ b/events/opensearchcon/2024/north-america/index.md
@@ -14,6 +14,8 @@ hero_images:
 #    path: /assets/media/opensearchcon/2024/OSC2024_NASF_Web-banner_1440x360.png
 #    alt: OpenSearchCon 2024 hero banner image.
 conference_sections_button_stack:
+  - label: Schedule
+    url: /events/opensearchcon/2024/north-america/schedule.html
   - label: Capture the Flag
     url: /events/opensearchcon/2024/north-america/capture-the-flag.html
   - label: Search Relevance Training
@@ -37,22 +39,7 @@ related_articles:
     url: /blog/opensearchcon-san-francisco-schedule-and-cfp-updates/
     category: community
     date: 'Fri, Jul 21, 2024'
-#featured_sessions:
-#  - title: Opening Keynote
-#    url: /events/opensearchcon/2022/north-america/sessions/keynote.html
-#    date: Wednesday 09/21/2022
-#    thumbnail: /assets/media/opensearchcon/2022-keynote-thumbnail.png
-#    category: Community
-#  - title: Getting Started with the OpenSearch Core Codebase
-#    url: >-
-#      /events/opensearchcon/2022/north-america/sessions/getting-started-with-opensearch-core-codebase.html
-#    date: Wednesday 9/21/2022
-#    thumbnail: /assets/media/opensearchcon/2022-getting-started.png
-#  - title: OpenSearch Project Roadmap 2022 and Beyond
-#    url: >-
-#      /events/opensearchcon/2022/north-america/sessions/opensearch-project-roadmap-2022-and-beyond.html
-#    date: Wednesday 09/21/2022
-#    thumbnail: /assets/media/opensearchcon/2022-roadmap-and-beyond.png
+
 ---
 
 ### **Join us in San Francisco, September 24-26, 2024 for OpenSearchCon North America!**
@@ -100,134 +87,3 @@ OpenSearchCon is the annual conference that brings the OpenSearch community toge
 We have watched OpenSearchCon North America grow from its humble beginnings as a single-track, one-day event to a three-day, multi-track open source community experience that includes an unconference, training and workshops, a partner round table, and other exciting networking and partner opportunities.
 
 We hope to see  you in San Francisco!
-
-
-### Day 1 - Tuesday, September 24, 2024 
-
-Opening day will have our main keynote speech, two session rooms running, and a couple of special events, including an evening reception with appetizers and beer/wine.
-
-
-<table class="oscon2024-north-america" style="border: 1px solid black; width: 100%" width="100%">
-<tr>
-    <td>7:00am-8:50am</td>
-    <td>Continental breakfast - Golden Gate Ballroom</td>
-</tr>
-<tr>
-    <td>7:00am-5:00pm</td>
-    <td>Registration open - Golden Gate Ballroom Foyer</td>
-</tr>
-<tr>
-    <td>7:00am-5:00pm</td>
-    <td>Exhibitor setup - East Foyer Lounge</td>
-</tr>
-<tr>
-    <td>9:00am-9:50am</td>
-    <td>Opening keynote by Eli Fisher - Main Stage/Continental Rooms 4-5
-</td>
-</tr>
-<tr>
-    <td>10:00am-5:30pm</td>
-    <td>Attendee Lounge - Continental 6
-</td>
-</tr>
-<tr>
-    <td>10:00am-12:00pm</td>
-    <td>Partner round table - Continental Rooms 7-9
-</td>
-</tr>
-<tr>
-    <td>10:00am-12:00pm</td>
-    <td>General sessions - Continental Rooms 1-3
-</td>
-</tr>
-<tr>
-    <td>12:00pm-12:55pm</td>
-    <td>Hosted Lunch - Golden Gate Ballroom</td>
-</tr>
-<tr>
-    <td>1:00pm-4:00pm</td>
-    <td>The Unconference</td>
-</tr>
-<tr>
-    <td>1:00pm-5:30pm</td>
-    <td>General sessions - Continental Rooms 1-3
-</td>
-</tr>
-</table>
-
-
-### Day 2 - Wednesday, September 25
-
-The main session day of the conference. Sessions will be running in three rooms, all day, right up to the Search Party starting at 5:30pm.
-
-
-<table class="oscon2024-europe" style="border: 1px solid black; width: 100%" width="100%">
-<tr>
-    <td>7:00am-8:50am</td>
-    <td>Continental breakfast - Golden Gate Ballroom</td>
-</tr>
-<tr>
-    <td>7:00am-5:30pm</td>
-    <td>Registration open - Golden Gate Ballroom Foyer</td>
-</tr>
-<tr>
-    <td>9:00am-5:30pm</td>
-    <td>Exhibitor area open - East Foyer Lounge
-</td>
-</tr>
-<tr>
-    <td>9:00am-9:10am</td>
-    <td>Opening remarks - Main Stage/Continental Rooms 4-5</td>
-</tr>
-<tr>
-    <td>9:15am-5:30pm</td>
-    <td>Attendee Lounge - Continental Room 6</td>
-</tr>
-<tr>
-    <td>9:15am-12:00pm</td>
-    <td>Main stage sessions - Continental Rooms 4-5</td>
-</tr>
-<tr>
-    <td>9:15am-12:00pm</td>
-    <td>General sessions - Continental Rooms 1-3</td>
-</tr>
-<tr>
-    <td>9:15am-12:00pm</td>
-    <td>General sessions - Continental Rooms 7-9</td>
-</tr>
-<tr>
-    <td>12:00pm-12:55pm</td>
-    <td>Hosted Lunch - Golden Gate Ballroom</td>
-</tr>
-<tr><td>1:00pm-5:30pm</td><td> Main stage sessions - Continental Rooms 4-5 </td></tr>
-<tr><td>1:00pm-5:30pm</td><td> General sessions - Continental Rooms 1-3</td></tr>
-<tr><td>1:00pm-5:30pm</td><td> General sessions - Continental Rooms 7-9</td></tr>
-<tr><td>5:30pm-7:00pm</td><td> The search party! - East Foyer Lounge</td></tr>
-
-</table>
-
-### Day 3 - Thursday, September 26
-
-Day three is dedicated to training, workshops, and a capture the flag (CTF awards ceremony at 4pm)
-
-<table class="oscon2024-europe" style="border: 1px solid black; width: 100%" width="100%">
-<tr><td>7:00am-8:50am</td><td>Continental breakfast - Continental Room 4</td></tr>
-<tr><td>7:00am-9:00am</td><td>Registration open - East Foyer Lounge</td></tr>
-<tr><td>8:00am-12:00pm</td><td>Search training - Continental Rooms 1 & 3</td></tr>
-<tr><td>9:00am-12:00pm</td> <td>OpenSearch workshop - Continental Room 2</td></tr>
-<tr><td>10:00am-12:00pm</td><td>Capture the Flag sponsored by Graylog - Continental Room 4</td></tr>
-<tr><td>12:00pm-12:55pm</td><td>Hosted Lunch - Continental Room 4</td></tr>
-<tr><td>1:00pm-5:00pm</td><td>Search training - Continental Rooms 1 & 3</td></tr>
-<tr><td>1:00pm-4:30pm</td><td>Capture the Flag sponsored by Graylog - Continental Room 4</td></tr>
-</table>
-
-
-
-
-
-
-
-
-
-
-

--- a/events/opensearchcon/2024/north-america/schedule.md
+++ b/events/opensearchcon/2024/north-america/schedule.md
@@ -1,0 +1,128 @@
+---
+layout: redesign-fullwidth
+title: 'OpenSearchCon 2024: North America - Schedule'
+primary_title: 'OpenSearchCon 2024: North America - Schedule'
+conference_id: 2024-north-america
+---
+<div class="full-width-layout--content">
+<div class="full-width-layout--content--body">
+
+<h3> Day 1 - Tuesday, September 24, 2024 </h3>
+<p>Opening day will have our main keynote speech, two session rooms running, and a couple of special events, including an evening reception with appetizers and beer/wine.</p>
+
+
+
+<table class="oscon2024-north-america data-table" style="border: 1px solid black; width: 100%" width="100%">
+<tr>
+    <td>7:00am-8:50am</td>
+    <td>Continental breakfast - Golden Gate Ballroom</td>
+</tr>
+<tr>
+    <td>7:00am-5:00pm</td>
+    <td>Registration open - Golden Gate Ballroom Foyer</td>
+</tr>
+<tr>
+    <td>7:00am-5:00pm</td>
+    <td>Exhibitor setup - East Foyer Lounge</td>
+</tr>
+<tr>
+    <td>9:00am-9:50am</td>
+    <td>Opening keynote by Eli Fisher - Main Stage/Continental Rooms 4-5
+</td>
+</tr>
+<tr>
+    <td>10:00am-5:30pm</td>
+    <td>Attendee Lounge - Continental 6
+</td>
+</tr>
+<tr>
+    <td>10:00am-12:00pm</td>
+    <td>Partner round table - Continental Rooms 7-9
+</td>
+</tr>
+<tr>
+    <td>10:00am-12:00pm</td>
+    <td>General sessions - Continental Rooms 1-3
+</td>
+</tr>
+<tr>
+    <td>12:00pm-12:55pm</td>
+    <td>Hosted Lunch - Golden Gate Ballroom</td>
+</tr>
+<tr>
+    <td>1:00pm-4:00pm</td>
+    <td>The Unconference</td>
+</tr>
+<tr>
+    <td>1:00pm-5:30pm</td>
+    <td>General sessions - Continental Rooms 1-3
+</td>
+</tr>
+</table>
+
+<h3> Day 2 - Wednesday, September 25 </h3>
+<p>The main session day of the conference. Sessions will be running in three rooms, all day, right up to the Search Party starting at 5:30pm.</p>
+
+
+<table class="oscon2024-europe" style="border: 1px solid black; width: 100%" width="100%">
+<tr>
+    <td>7:00am-8:50am</td>
+    <td>Continental breakfast - Golden Gate Ballroom</td>
+</tr>
+<tr>
+    <td>7:00am-5:30pm</td>
+    <td>Registration open - Golden Gate Ballroom Foyer</td>
+</tr>
+<tr>
+    <td>9:00am-5:30pm</td>
+    <td>Exhibitor area open - East Foyer Lounge
+</td>
+</tr>
+<tr>
+    <td>9:00am-9:10am</td>
+    <td>Opening remarks - Main Stage/Continental Rooms 4-5</td>
+</tr>
+<tr>
+    <td>9:15am-5:30pm</td>
+    <td>Attendee Lounge - Continental Room 6</td>
+</tr>
+<tr>
+    <td>9:15am-12:00pm</td>
+    <td>Main stage sessions - Continental Rooms 4-5</td>
+</tr>
+<tr>
+    <td>9:15am-12:00pm</td>
+    <td>General sessions - Continental Rooms 1-3</td>
+</tr>
+<tr>
+    <td>9:15am-12:00pm</td>
+    <td>General sessions - Continental Rooms 7-9</td>
+</tr>
+<tr>
+    <td>12:00pm-12:55pm</td>
+    <td>Hosted Lunch - Golden Gate Ballroom</td>
+</tr>
+<tr><td>1:00pm-5:30pm</td><td> Main stage sessions - Continental Rooms 4-5 </td></tr>
+<tr><td>1:00pm-5:30pm</td><td> General sessions - Continental Rooms 1-3</td></tr>
+<tr><td>1:00pm-5:30pm</td><td> General sessions - Continental Rooms 7-9</td></tr>
+<tr><td>5:30pm-7:00pm</td><td> The search party! - East Foyer Lounge</td></tr>
+
+</table>
+
+<h3> Day 3 - Thursday, September 26 </h3>
+<p>Day three is dedicated to training, workshops, and a capture the flag (CTF awards ceremony at 4pm)</p>
+
+<table class="oscon2024-europe" style="border: 1px solid black; width: 100%" width="100%">
+<tr><td>7:00am-8:50am</td><td>Continental breakfast - Continental Room 4</td></tr>
+<tr><td>7:00am-9:00am</td><td>Registration open - East Foyer Lounge</td></tr>
+<tr><td>8:00am-12:00pm</td><td>Search training - Continental Rooms 1 & 3</td></tr>
+<tr><td>9:00am-12:00pm</td> <td>OpenSearch workshop - Continental Room 2</td></tr>
+<tr><td>10:00am-12:00pm</td><td>Capture the Flag sponsored by Graylog - Continental Room 4</td></tr>
+<tr><td>12:00pm-12:55pm</td><td>Hosted Lunch - Continental Room 4</td></tr>
+<tr><td>1:00pm-5:00pm</td><td>Search training - Continental Rooms 1 & 3</td></tr>
+<tr><td>1:00pm-4:30pm</td><td>Capture the Flag sponsored by Graylog - Continental Room 4</td></tr>
+</table>
+
+
+</div>
+</div>

--- a/release-metrics/index.md
+++ b/release-metrics/index.md
@@ -1,0 +1,197 @@
+---
+layout: fullwidth-with-breadcrumbs
+primary_title: 'OpenSearch Release Metrics'
+title: 'OpenSearch Release Metrics'
+breadcrumbs:
+  icon: platform
+  items:
+    - title: The OpenSearch Platform
+      url: '/platform/'
+    - title: Release Metrics
+      url: '/release-metrics/'
+omit_from_search: true
+
+benchmark_domain: 'metrics.opensearch.org'
+benchmark_dashboard_id: '88071cb0-f118-11ed-aff5-859eb6ed880f'
+benchmark_range_days: 7
+
+benchmark_height_desktop: 2000
+benchmark_height_mobile: 6000
+---
+<style>
+    body, html {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        background-color: #fff;
+    }
+    h1 {
+        text-align: center;
+        margin: 5px 0;
+        cursor: pointer;
+        text-decoration: underline;
+    }
+    .dashboard-container {
+        width: 100%;
+        margin-bottom: 20px;
+        overflow: hidden;
+    }
+    iframe {
+        width: 100%;
+        border: none;
+    }
+    @media only screen and (min-width: 768px) {
+        iframe {
+            height: {{ page.benchmark_height_desktop }}px;
+        }
+    }
+    @media only screen and (max-width: 767px) {
+        iframe {
+            height: {{ page.benchmark_height_mobile }}px;
+        }
+    }
+    .modal {
+        display: none;
+        position: fixed;
+        z-index: 1000;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background-color: rgba(0,0,0,0.5);
+        justify-content: center;
+        align-items: center;
+    }
+    .modal-content {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        max-width: 1200px;
+        max-height: 900px
+        background-color: white;
+        overflow: hidden;
+    }
+    .modal-header {
+        padding: 16px;
+        font-size: 20px;
+        font-weight: bold;
+        border-bottom: 1px solid #ddd;
+        background-color: #f5f5f5;
+        margin-bottom: 16px;
+    }
+    .close {
+        position: absolute;
+        right: 20px;
+        top: 20px;
+        color: #000;
+        font-size: 28px;
+        font-weight: bold;
+        cursor: pointer;
+        z-index: 2;
+    }
+    .close:hover,
+    .close:focus {
+        color: #555; 
+        text-decoration: none;
+        cursor: pointer;
+    }
+    .modal-body {
+        padding: 16px;
+        height: calc(100% - 60px);
+        overflow: auto;
+    }
+    .nav-index {
+        margin: 5px;
+        text-align: center;
+    }
+    .nav-index a {
+        margin: 0 15px;
+        text-decoration: none;
+        color: #007bff;
+        font-weight: bold;
+    }
+    .nav-index a:hover {
+        text-decoration: underline;
+    }
+    .button {
+        display: inline-block;
+        padding: 10px 15px;
+        font-size: 14px;
+        color: #fff;
+        background-color: #007bff;
+        text-decoration: none;
+        border-radius: 4px;
+        margin-top: 10px;
+    }
+    .button:hover {
+        background-color: #0056b3;
+    }
+</style>
+
+<div class="nav-index">
+    <a href="#metrics-dashboard">OpenSearch Release Metrics</a>
+    <a href="#test-results-dashboard">OpenSearch Release Build and Integration Test Results</a>
+</div>
+
+<p> 
+    Welcome to the OpenSearch Release Metrics page. As part of the <a href="https://github.com/opensearch-project/opensearch-metrics">metrics project initiative</a> and with the goal of providing a central release dashboard, this page offers a comprehensive overview of the metrics and key indicators related to the ongoing OpenSearch releases. It provides a consolidated view of all release-related metrics, helping the the OpenSearch community to track release progress and its activities effectively. The page features dashboards and visualizations that support the community, plugin teams, and release managers by offering essential data to ensure a smooth release process. Additionally, it includes dashboards for build and integration test failures, which are particularly valuable for component-level release owners as these dashboards help in identifying and addressing issues before and during the release window.
+</p>
+<h2>Join the discussion</h2>
+<p>
+    Questions or contributions? Connect with the OpenSearch community in the <a href="https://opensearch.slack.com/archives/C0561HRK961">#releases</a> channel on our public Slack.
+</p>
+
+<p>
+    To learn more about OpenSearch Release Process, please read this <a href="https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution">wiki document</a> part of the opensearch-build repo.
+</p>
+
+<div id="metrics-dashboard" class="dashboard-container">
+    <h1 onclick="openModal('modal1')">OpenSearch Release Metrics</h1>
+    <a href="https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/12d47dd0-e0cc-11ee-86f3-3358a59f8c46?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-90d,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Metrics',viewMode:view)&show-top-menu=true&show-query-input=true&show-time-filter=true" target="_blank" class="button">Direct Link to Metrics Dashboard</a>
+    <iframe src="https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/12d47dd0-e0cc-11ee-86f3-3358a59f8c46?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-90d,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Metrics',viewMode:view)&show-top-menu=true&show-query-input=true&show-time-filter=true"></iframe>
+</div>
+
+<div id="test-results-dashboard" class="dashboard-container">
+    <h1 onclick="openModal('modal2')">OpenSearch Release Build and Integration Test Results</h1>
+    <a href="https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/21aad140-49f6-11ef-bbdd-39a9b324a5aa?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d,to:now))&_a=(description:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',viewMode:view)&show-top-menu=true&show-query-input=true&show-time-filter=tru" target="_blank" class="button">Direct Link to Metrics Dashboard</a>
+    <iframe src="https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/21aad140-49f6-11ef-bbdd-39a9b324a5aa?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d,to:now))&_a=(description:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',viewMode:view)&show-top-menu=true&show-query-input=true&show-time-filter=true"></iframe>
+</div>
+
+<!-- First Modal -->
+<div id="modal1" class="modal">
+    <div class="modal-content">
+        <div class="modal-header">
+            <span class="close" onclick="closeModal('modal1')">&times;</span>
+            OpenSearch Release Metrics
+        </div>
+        <div class="modal-body">
+            <iframe src="https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/12d47dd0-e0cc-11ee-86f3-3358a59f8c46?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-90d,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Metrics',viewMode:view)&show-top-menu=true&show-query-input=true&show-time-filter=true"></iframe>
+        </div>
+    </div>
+</div>
+
+<!-- Second Modal -->
+<div id="modal2" class="modal">
+    <div class="modal-content">
+        <div class="modal-header">
+            <span class="close" onclick="closeModal('modal2')">&times;</span>
+            OpenSearch Release Build and Integration Test Results
+        </div>
+        <div class="modal-body">
+            <iframe src="https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/21aad140-49f6-11ef-bbdd-39a9b324a5aa?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d,to:now))&_a=(description:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Release%20Build%20and%20Integration%20Test%20Results',viewMode:view)&show-top-menu=true&show-query-input=true&show-time-filter=true"></iframe>
+        </div>
+    </div>
+</div>
+
+<script>
+    function openModal(modalId) {
+        document.getElementById(modalId).style.display = "flex";
+    }
+    function closeModal(modalId) {
+        document.getElementById(modalId).style.display = "none";
+    }
+</script>

--- a/releases.md
+++ b/releases.md
@@ -38,7 +38,7 @@ Note:  We have not added a major release to the 2024 schedule yet.  If/when we a
 | 1.3.18         | July 09th, 2024                           | July 16th, 2024                                      | [Zelin Hao](https://github.com/zelinh/)              | [4763](https://github.com/opensearch-project/opensearch-build/issues/4763) |
 | 2.16.0         | July 23rd, 2024                           | August ~~06th~~07th 2024                             | [Prudhvi Godithi](https://github.com/prudhvigodithi) | [4771](https://github.com/opensearch-project/opensearch-build/issues/4771) |
 | 1.3.19         | Aug 20th, 2024                            | August 27th, 2024                                    | [Brandon Shien](https://github.com/bshien)           | [4888](https://github.com/opensearch-project/opensearch-build/issues/4888) |
-| 2.17.0         | September ~~03rd~~ 04th, 2024             | September 17th, 2024                                 | [Sayali Gaikawad](https://github.com/gaiksaya/)      | [4908](https://github.com/opensearch-project/opensearch-build/issues/4908) |
+| 2.17.0         | September ~~04th~~ 05th, 2024             | September 17th, 2024                                 | [Sayali Gaikawad](https://github.com/gaiksaya/)      | [4908](https://github.com/opensearch-project/opensearch-build/issues/4908) |
 | 2.18.0         | October 22nd, 2024                        | November 05th, 2024                                  |                                                      |                                                                            |
 | 1.3.20         | December 03rd, 2024                       | December 10th, 2024                                  |                                                      |                                                                            |
 | 2.19.0         | January 28th, 2025                        | Feb 11th, 2025                                       |                                                      |                                                                            | 
@@ -153,4 +153,5 @@ The software maintainers will not back-port fixes or features to versions outsid
 | April 26th, 2024     | Update release manager for 1.3.16 release          | [1.3.16 release issue](https://github.com/opensearch-project/opensearch-build/issues/4531)       |
 | August 28th, 2024    | Update release history from February to August 2024 | Update page |
 | September 3rd, 2024  | Update release history from 2021 to 2023 | Update page |
+| September 4th, 2024  | Update Release candidate generation date for 2.17.0 | Too many last minute PRs causing CI build issues |
 {: .desktop-change-log-table}

--- a/releases.md
+++ b/releases.md
@@ -78,56 +78,70 @@ The software maintainers will not back-port fixes or features to versions outsid
 ## Release History ##
 
 
-| Release Number |  Release Date       | Release Manager                                                                                                                          | Tracking Issue |
-|:---------------|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------------------|
-| 1.3.19         | August 27th, 2024   | [Brandon Shien](https://github.com/bshien)                                                                                               | [4888](https://github.com/opensearch-project/opensearch-build/issues/4888) |
-| 2.16.0         | August 07th 2024    | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                     | [4771](https://github.com/opensearch-project/opensearch-build/issues/4771) |
-| 1.3.18         | July 16th, 2024     | [Zelin Hao](https://github.com/zelinh/)                                                                                                  | [4763](https://github.com/opensearch-project/opensearch-build/issues/4763) |
-| 2.15.0         | June 25th, 2024     | [Peter Zhu](https://github.com/peterzhuamazon)                                                                                           | [4681](https://github.com/opensearch-project/opensearch-build/issues/4681) |
-| 1.3.17         | June 06th, 2024     | [Divya Madala](https://github.com/Divyaasm/)                                                                                             | [4659](https://github.com/opensearch-project/opensearch-build/issues/4659) |
-| 2.14.0         | May 14th, 2024      | [Rishabh Singh](https://github.com/rishabh6788/)                                                                                         | [4562](https://github.com/opensearch-project/opensearch-build/issues/4562) |
-| 1.3.16         | April 23rd, 2024    | [Zelin Hao](https://github.com/zelinh/)                                                                                                  | [4531](https://github.com/opensearch-project/opensearch-build/issues/4531) |
-| 2.13.0         | April 2nd, 2024     | [Sayali Gaikawad](https://github.com/gaiksaya)                                                                                           | [4433](https://github.com/opensearch-project/opensearch-build/issues/4433) |
-| 1.3.15         | March 05 2024       | [Jeff Lu](https://github.com/jordarlu)                                                                                                   | [4294](https://github.com/opensearch-project/opensearch-build/issues/4294) |
-| 2.12.0         | February 20th 2024  | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                     | [4115](https://github.com/opensearch-project/opensearch-build/issues/4115) |
-| 1.3.14         | December 12th 2023  | [Zelin Hao](https://github.com/zelinh)                                                                                                   | [4069](https://github.com/opensearch-project/opensearch-build/issues/4069) |
-| 2.11.1         | November 30th       | [Divya Madala](https://github.com/Divyaasm)                                                                                              | [4161](https://github.com/opensearch-project/opensearch-build/issues/4161) |
-| 2.11.0         | October 16th        | [Rishabh Singh](https://github.com/rishabh6788) & [Peter Zhu](https://github.com/peterzhuamazon)                                         | [3998](https://github.com/opensearch-project/opensearch-build/issues/3998) |
-| 1.3.13         | September 21st      | [Zelin Hao](https://github.com/zelinh)                                                                                                   | [3878](https://github.com/opensearch-project/opensearch-build/issues/3878) |
-| 2.10.0         | September 25th      | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                     | [3777](https://github.com/opensearch-project/opensearch-build/issues/3777) |
-| 1.3.11         | June 29th, 2023     | [Jeff Lu](https://github.com/jordarlu)                                                                                                   | [3630](https://github.com/opensearch-project/opensearch-build/issues/3630) |
-| 2.9.0          | July 24th, 2023     | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                     | [3762](https://github.com/opensearch-project/opensearch-build/issues/3762) |
-| 2.8.0          | June 6th, 2023      | [Rishabh Singh](https://github.com/rishabh6788) & [Peter Zhu](https://github.com/peterzhuamazon)                                         | [3434](https://github.com/opensearch-project/opensearch-build/issues/3434) |
-| 1.3.10         | May 11th, 2023      | [Prudhvi Godithi](https://github.com/prudhvigodithi) & [Peter Zhu](https://github.com/peterzhuamazon)                                    | [3331](https://github.com/opensearch-project/opensearch-build/issues/3331) |
-| 2.7.0          | April 17th, 2023    | [Peter Zhu](https://github.com/peterzhuamazon) & [Zelin Hao](https://github.com/zelinh)                                                  | [3230](https://github.com/opensearch-project/opensearch-build/issues/3230) |
-| 1.3.9          | March 9th, 2023     | [Jeff Lu](https://github.com/jordarlu)                                                                                                   | [3195](https://github.com/opensearch-project/opensearch-build/issues/3195) |
-| 2.6.0          | February 28th, 2023 | [Sayali Gaikawad](https://github.com/gaiksaya)                                                                                           | [3081](https://github.com/opensearch-project/opensearch-build/issues/3081) |
-| 1.3.8          | February 2nd, 2023 | [Rishabh Singh](https://github.com/rishabh6788) & [Divya Madala](https://github.com/Divyaasm)                                            | [3012](https://github.com/opensearch-project/opensearch-build/issues/3012) |
-| 2.5.0          | January 24th, 2023 | [Rishabh Singh](https://github.com/rishabh6788), [Peter Zhu](https://github.com/peterzhuamazon) & [Zelin Hao](https://github.com/zelinh) | [2908](https://github.com/opensearch-project/opensearch-build/issues/2908) |
-| 1.3.7          | December 13, 2022  |
-| 2.4            | November 15, 2022  |
-| 1.3.6          | October 6, 2022    |
-| 2.3            | September 14, 2022 |
-| 2.2.1          | September 1, 2022  |
-| 1.3.5          | September 1, 2022  |
-| 2.2            | August 11, 2022    |
-| 1.3.4          | July 14, 2022      |
-| 2.1            | July 7, 2022       |
+| Release Number |  Release Date        | Release Manager                                                                                                                                 | Tracking Issue |
+|:---------------|:---------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------|
+| 1.3.19         | August 27th, 2024    | [Brandon Shien](https://github.com/bshien)                                                                                                      | [4888](https://github.com/opensearch-project/opensearch-build/issues/4888) |
+| 2.16.0         | August 07th 2024     | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                            | [4771](https://github.com/opensearch-project/opensearch-build/issues/4771) |
+| 1.3.18         | July 16th, 2024      | [Zelin Hao](https://github.com/zelinh/)                                                                                                         | [4763](https://github.com/opensearch-project/opensearch-build/issues/4763) |
+| 2.15.0         | June 25th, 2024      | [Peter Zhu](https://github.com/peterzhuamazon)                                                                                                  | [4681](https://github.com/opensearch-project/opensearch-build/issues/4681) |
+| 1.3.17         | June 06th, 2024      | [Divya Madala](https://github.com/Divyaasm/)                                                                                                    | [4659](https://github.com/opensearch-project/opensearch-build/issues/4659) |
+| 2.14.0         | May 14th, 2024       | [Rishabh Singh](https://github.com/rishabh6788/)                                                                                                | [4562](https://github.com/opensearch-project/opensearch-build/issues/4562) |
+| 1.3.16         | April 23rd, 2024     | [Zelin Hao](https://github.com/zelinh/)                                                                                                         | [4531](https://github.com/opensearch-project/opensearch-build/issues/4531) |
+| 2.13.0         | April 2nd, 2024      | [Sayali Gaikawad](https://github.com/gaiksaya)                                                                                                  | [4433](https://github.com/opensearch-project/opensearch-build/issues/4433) |
+| 1.3.15         | March 05th 2024      | [Jeff Lu](https://github.com/jordarlu)                                                                                                          | [4294](https://github.com/opensearch-project/opensearch-build/issues/4294) |
+| 2.12.0         | February 20th 2024   | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                            | [4115](https://github.com/opensearch-project/opensearch-build/issues/4115) |
+| 1.3.14         | December 12th 2023   | [Zelin Hao](https://github.com/zelinh)                                                                                                          | [4069](https://github.com/opensearch-project/opensearch-build/issues/4069) |
+| 2.11.1         | November 30th, 2023  | [Divya Madala](https://github.com/Divyaasm)                                                                                                     | [4161](https://github.com/opensearch-project/opensearch-build/issues/4161) |
+| 2.11.0         | October 16th, 2023   | [Rishabh Singh](https://github.com/rishabh6788) & [Peter Zhu](https://github.com/peterzhuamazon)                                                | [3998](https://github.com/opensearch-project/opensearch-build/issues/3998) |
+| 1.3.13         | September 21st       | [Zelin Hao](https://github.com/zelinh)                                                                                                          | [3878](https://github.com/opensearch-project/opensearch-build/issues/3878) |
+| 2.10.0         | September 25th       | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                            | [3777](https://github.com/opensearch-project/opensearch-build/issues/3777) |
+| 1.3.11         | June 29th, 2023      | [Jeff Lu](https://github.com/jordarlu)                                                                                                          | [3630](https://github.com/opensearch-project/opensearch-build/issues/3630) |
+| 2.9.0          | July 24th, 2023      | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                            | [3762](https://github.com/opensearch-project/opensearch-build/issues/3762) |
+| 2.8.0          | June 6th, 2023       | [Rishabh Singh](https://github.com/rishabh6788) & [Peter Zhu](https://github.com/peterzhuamazon)                                                | [3434](https://github.com/opensearch-project/opensearch-build/issues/3434) |
+| 1.3.10         | May 11th, 2023       | [Prudhvi Godithi](https://github.com/prudhvigodithi) & [Peter Zhu](https://github.com/peterzhuamazon)                                           | [3331](https://github.com/opensearch-project/opensearch-build/issues/3331) |
+| 2.7.0          | April 17th, 2023     | [Peter Zhu](https://github.com/peterzhuamazon) & [Zelin Hao](https://github.com/zelinh)                                                         | [3230](https://github.com/opensearch-project/opensearch-build/issues/3230) |
+| 1.3.9          | March 9th, 2023      | [Jeff Lu](https://github.com/jordarlu)                                                                                                          | [3195](https://github.com/opensearch-project/opensearch-build/issues/3195) |
+| 2.6.0          | February 28th, 2023  | [Sayali Gaikawad](https://github.com/gaiksaya)                                                                                                  | [3081](https://github.com/opensearch-project/opensearch-build/issues/3081) |
+| 1.3.8          | February 2nd, 2023   | [Rishabh Singh](https://github.com/rishabh6788) & [Divya Madala](https://github.com/Divyaasm)                                                   | [3012](https://github.com/opensearch-project/opensearch-build/issues/3012) |
+| 2.5.0          | January 24th, 2023   | [Rishabh Singh](https://github.com/rishabh6788), [Peter Zhu](https://github.com/peterzhuamazon) & [Zelin Hao](https://github.com/zelinh)        | [2908](https://github.com/opensearch-project/opensearch-build/issues/2908) |
+| 1.3.7          | December 13th, 2022  | [Peter Zhu](https://github.com/peterzhuamazon) & [Rishabh Singh](https://github.com/rishabh6788)                                                | [2742](https://github.com/opensearch-project/opensearch-build/issues/2742) |
+| 2.4.0          | November 15th, 2022  | [Peter Zhu](https://github.com/peterzhuamazon)                                                                                                  | [2649](https://github.com/opensearch-project/opensearch-build/issues/2649) |
+| 1.3.6          | October 6th, 2022    | [Zelin Hao](https://github.com/zelinh)                                                                                                          | [2650](https://github.com/opensearch-project/opensearch-build/issues/2650) |
+| 2.3.0          | September 14th, 2022 | [Sayali Gaikawad](https://github.com/gaiksaya)                                                                                                  | [2447](https://github.com/opensearch-project/opensearch-build/issues/2447) |
+| 2.2.1          | September 1st, 2022  | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                            | [2481](https://github.com/opensearch-project/opensearch-build/issues/2481) |
+| 1.3.5          | September 1st, 2022  | [Prudhvi Godithi](https://github.com/prudhvigodithi)                                                                                            | [2348](https://github.com/opensearch-project/opensearch-build/issues/2348) |
+| 2.2.0          | August 11th, 2022    | [Peter Zhu](https://github.com/peterzhuamazon)                                                                                                  | [2271](https://github.com/opensearch-project/opensearch-build/issues/2271) |
+| 1.3.4          | July 14th, 2022      | [Zelin Hao](https://github.com/zelinh)                                                                                                          | [2205](https://github.com/opensearch-project/opensearch-build/issues/2205) |
+| 2.1.0          | July 7th, 2022       | [Sayali Gaikawad](https://github.com/gaiksaya)                                                                                                  | [1818](https://github.com/opensearch-project/opensearch-build/issues/1818) |
+| 2.0.1          | June 16th, 2022      | [Zelin Hao](https://github.com/zelinh) & [Peter Zhu](https://github.com/peterzhuamazon)                                                         | [2165](https://github.com/opensearch-project/opensearch-build/issues/2165) |
+| 1.3.3          | June 09th, 2022      | [Prudhvi Godithi](https://github.com/prudhvigodithi) & [Peter Zhu](https://github.com/peterzhuamazon)                                           | [2101](https://github.com/opensearch-project/opensearch-build/issues/2101) |
+| 2.0.0          | May 26th, 2022       | [Peter Zhu](https://github.com/peterzhuamazon)                                                                                                  | [2086](https://github.com/opensearch-project/opensearch-build/issues/2086) |
+| 1.3.2          | May 5th, 2022        | [Zelin Hao](https://github.com/zelinh)                                                                                                          | [1882](https://github.com/opensearch-project/opensearch-build/issues/1882) |
+| 2.0.0-rc1      | May 3rd, 2022        | [Peter Zhu](https://github.com/peterzhuamazon) & [Zelin Hao](https://github.com/zelinh)                                                         | [1624](https://github.com/opensearch-project/opensearch-build/issues/1624) |
+| 1.3.1          | March 30th, 2022     | [Abhinav Gupta](https://github.com/abhinavGupta16)                                                                                              | [1885](https://github.com/opensearch-project/opensearch-build/issues/1885) |
+| 1.3.0          | March 17th, 2022     | [Zelin Hao](https://github.com/zelinh) & [Peter Zhu](https://github.com/peterzhuamazon)                                                         | [889](https://github.com/opensearch-project/opensearch-build/issues/889)   |
+| 1.2.4          | January 18th, 2022   | [Abhinav Gupta](https://github.com/abhinavGupta16) & [Peter Zhu](https://github.com/peterzhuamazon)                                             | [1417](https://github.com/opensearch-project/opensearch-build/issues/1417) |
+| 1.2.3          | December 22th, 2021  | [Peter Zhu](https://github.com/peterzhuamazon) & [Peter Nied](https://github.com/peternied)                                                     | [1365](https://github.com/opensearch-project/opensearch-build/issues/1365) |
+| 1.2.0          | November 23th, 2021  | [Sayali Gaikawad](https://github.com/gaiksaya), [Peter Zhu](https://github.com/peterzhuamazon) & [Peter Nied](https://github.com/peternied)     | [567](https://github.com/opensearch-project/opensearch-build/issues/567)   |
+| 1.1.0          | October 05th, 2021   | [Peter Zhu](https://github.com/peterzhuamazon)                                                                                                  | [564](https://github.com/opensearch-project/opensearch-build/issues/564)   |
+| 1.0.1          | September 01, 2021   | [Abhinav Gupta](https://github.com/abhinavGupta16)                                                                                              | [151](https://github.com/opensearch-project/opensearch-build/issues/151)   |
+| 1.0.0          | July 12th, 2021      | [Peter Zhu](https://github.com/peterzhuamazon) & [Sayali Gaikawad](https://github.com/gaiksaya)                                                 | [85](https://github.com/opensearch-project/opensearch-build/pull/85)       |
+| 1.0.0-rc1      | June 7th, 2021       | [Peter Zhu](https://github.com/peterzhuamazon), [Sayali Gaikawad](https://github.com/gaiksaya) & [Sreekar Jami](https://github.com/sreekarjami) | [48](https://github.com/opensearch-project/opensearch-build/pull/48)       |
 {: .data-table__half-width .desktop-release-history-table}
 
 ## Change Log ##
 
 | Date                 | Change | Reason          |
 |:---------------------|:-------|:----------------|
-| July 1, 2022         |        | Initial Version |
-| October 20,2022      | Increased time between 2.5 code freeze and release | 7 days is standard, and there were only 2 days for 2.5 |
-| October 20,2022      | Added Initial 2023 schedule|Current schedule was running out|
-| January 13, 2023     | Update to 2.5.0 release date  | Maps team found last minute issue, moving to accommodate resolution  |
-| January 19, 2023     | Update to 2.5.0 release date  | Docs team due diligence, moving to accommodate  |
-| April 26, 2023       | Update to 2.7.0 release date  | Found CVE to resolve, fix issues found in regression tests  |
-| July 17, 2023        | Update to 2.9.0 release date  | No-Go on the release meeting call - build issues  |
-| July 20, 2023        | Update to 2.9.0 release date  | No-Go on the release meeting call - build issues  |
-| August 14, 2023      | Updated release table to reflect release windows | per adoption of <https://github.com/opensearch-project/project-website/pull/1866> |
+| July 1st, 2022       |        | Initial Version |
+| October 20th, 2022   | Increased time between 2.5 code freeze and release | 7 days is standard, and there were only 2 days for 2.5 |
+| October 20th,2022    | Added Initial 2023 schedule|Current schedule was running out|
+| January 13th, 2023   | Update to 2.5.0 release date  | Maps team found last minute issue, moving to accommodate resolution  |
+| January 19th, 2023   | Update to 2.5.0 release date  | Docs team due diligence, moving to accommodate  |
+| April 26th, 2023     | Update to 2.7.0 release date  | Found CVE to resolve, fix issues found in regression tests  |
+| July 17th, 2023      | Update to 2.9.0 release date  | No-Go on the release meeting call - build issues  |
+| July 20th, 2023      | Update to 2.9.0 release date  | No-Go on the release meeting call - build issues  |
+| August 14th, 2023    | Updated release table to reflect release windows | per adoption of <https://github.com/opensearch-project/project-website/pull/1866> |
 | September 5th, 2023  | Updated 2.10 date  |  Original release date was too close to US Labor Day Holiday |
 | September 6th, 2023  | Updated 2.10 date  |  8 hour github outage last night - moving to accomodate a few final fixes |
 | September 11th, 2023 | Link to RELEASING.md  |  updated link from proposal to releasing documentation |
@@ -138,4 +152,5 @@ The software maintainers will not back-port fixes or features to versions outsid
 | February 21st, 2024  | Update release manager for 1.3.15 release          | [1.3.15 release issue](https://github.com/opensearch-project/opensearch-build/issues/4294)       |                                                                           
 | April 26th, 2024     | Update release manager for 1.3.16 release          | [1.3.16 release issue](https://github.com/opensearch-project/opensearch-build/issues/4531)       |
 | August 28th, 2024    | Update release history from February to August 2024 | Update page |
+| September 3rd, 2024  | Update release history from 2021 to 2023 | Update page |
 {: .desktop-change-log-table}


### PR DESCRIPTION
### Description
Navbar update to archive opensearchcons, 
Overall opensearchcon 2024 NA schedule. 
 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
