### PR TITLE
Add support for additional author info in blogs

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,6 +45,13 @@ primary_link_url: /blog
         
         {%- include author_panel.html author=author linked="true" -%}
     {% endfor %}
+
+    {% assign additional_author_info = page.additional_author_info  | default: '' %}
+    {% if additional_author_info.size > 0 %}
+        <div class="additional-author-info">
+            <p>{{additional_author_info}}</p>
+        </div>
+    {% endif %}
 </div>
 {% endcapture %}
 

--- a/_posts/_sample.markdown
+++ b/_posts/_sample.markdown
@@ -23,6 +23,9 @@ has_math: true
 # Setting to true will result in the inclusion of CSS styles specific to using borders for the table, for table header cells, and table data cells. scientific data tables. For reference see: _includes/science-table-styles.html.
 has_science_table: true
 
+# Provide additional info to be added to the bottom of the right column, after the author bios. Useful for including more authors, reviewers, or developers, to whom you want to give credit for the blog post.
+additional_author_info: Any additional information you want to include.
+
 # The layout template to use for rendering the content.
 # Options are default, fullwidth, homepage, and post.
 layout: post

--- a/_sass/_opensearch.scss
+++ b/_sass/_opensearch.scss
@@ -210,6 +210,12 @@
     }
 }
 
+.additional-author-info {
+    border-top: 1px solid $secondary-sanfrancisco-fog-s2;
+    margin-top: 2rem;
+    font-style: italic;
+}
+
 .tree, .tree ul {
     margin:0;
     padding:0;


### PR DESCRIPTION
Adds the ability to add other information (usually, credits to more authors, reviewers, or developers of the feature) on the bottom of the right column in blog posts.

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
