### PR TITLE
Update blog label category for search

### DIFF
--- a/_plugins/search-indexer.rb
+++ b/_plugins/search-indexer.rb
@@ -100,7 +100,7 @@ module Jekyll::ContentIndexer
       # Appropriately assign types based on collection
       case page.collection&.label
       when 'posts'
-        type = 'News'
+        type = 'Blogs'
       when 'authors'
         type = 'Authors'
       when 'events'


### PR DESCRIPTION
### Description
Update blog label category for search. 
We keep all blogs in the `_post` folder and `News` may sound confusing when user looks into the search results breadcrumb. Rename it to `Blogs`.
 
### Issues Resolved
Part of https://github.com/opensearch-project/project-website-search/issues/66

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
