### PR TITLE
[Backport] Backport PR from main branch: Update blog label category

### DIFF
--- a/_plugins/search-indexer.rb
+++ b/_plugins/search-indexer.rb
@@ -100,7 +100,7 @@ module Jekyll::ContentIndexer
       # Appropriately assign types based on collection
       case page.collection&.label
       when 'posts'
-        type = 'News'
+        type = 'Blogs'
       when 'authors'
         type = 'Authors'
       when 'events'

--- a/release-dashboard/index.md
+++ b/release-dashboard/index.md
@@ -48,16 +48,6 @@ metrics_height_mobile: 6000
         width: 100%;
         border: none;
     }
-    @media only screen and (min-width: 768px) {
-        iframe {
-            height: {{ page.benchmark_height_desktop }}px;
-        }
-    }
-    @media only screen and (max-width: 767px) {
-        iframe {
-            height: {{ page.benchmark_height_mobile }}px;
-        }
-    }
     .modal {
         display: none;
         position: fixed;
@@ -183,7 +173,7 @@ metrics_height_mobile: 6000
 <div id="metrics-dashboard" class="dashboard-container">
     <h1 onclick="openModal('modal1')">OpenSearch Release Metrics</h1>
     <a id="metrics-dashboard-link" href="#" target="_blank" class="button">Direct Link to Metrics Dashboard</a>
-    <iframe id="metrics-iframe" width="100%" height="{{ page.metrics_height_desktop }}"></iframe>
+    <iframe id="metrics-iframe" width="100%" height="1300"></iframe>
 </div>
 
 <div id="component-metrics-dashboard" class="dashboard-container">


### PR DESCRIPTION
### Description
Update blog label category for search.
We keep all blogs in the `_post` folder and `News` may sound confusing when user looks into the search results breadcrumb. Rename it to `Blogs`.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
