### PR TITLE
FIX: Pallavi Priyadarshini was not showing up in the list of speakers…

### DIFF
--- a/_community_members/pallp.md
+++ b/_community_members/pallp.md
@@ -8,20 +8,20 @@ primary_title: Pallavi Priyadarshini
 
 
 conference_id:
-  - 2024-north-america
+  - "2024-north-america"
 
 session_track:
-  - conference_id: 2024-north-america
+  - conference_id: "2024-north-america"
     name: Community
 
 personas:
   - conference_speaker
+  - author
   
 github: Pallavi-AWS
 linkedin: pallavipr
 job_title_and_company: 'Senior Engineering Manager at AWS'
-personas:
-  - author
+
 permalink: '/community/members/pallavi-priyadarshini.html'
 redirect_from: '/authors/pallp/'
 ---


### PR DESCRIPTION




### Description
This person was not showing up in the list of speakers. There was a typo in her .yml community members file that, once removed, she is now showing up. 
 She had two 'personas' parts of her community member file. I added both author and speaker to a single one.

### Issues Resolved
No issue, Patti messaged me directly

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
