### PR TITLE
Fix broken link in "Upcoming OpenSearchEvents" button

### DIFF
--- a/_includes/redesign_buttons.html
+++ b/_includes/redesign_buttons.html
@@ -150,7 +150,7 @@
         </div>
     {% when 'upcoming-events-dark' %}
         <div class="redesign-button--wrapper redesign-button--wrapper__text-only__dark">
-            <a href="/events/calendars/2024-01.html" class="redesign-button--anchor events-page-menu-link__device-based" id="upcoming-opensearch-events-button">
+            <a href="/events/" class="redesign-button--anchor events-page-menu-link__device-based" id="upcoming-opensearch-events-button">
                 Upcoming OpenSearch Events
             </a>
         </div>


### PR DESCRIPTION
### Description
On the [OpenSearchCon web page](https://opensearch.org/events/opensearchcon/2024/europe/index.html), there is a button in the left-hand column labeled "Upcoming OpenSearch Events", linking to `/events/calendars/2024-01.html`, which is a broken link.

<img width="378" alt="Skjermbilde 2024-09-19 kl  14 09 35" src="https://github.com/user-attachments/assets/00a1b4ed-60ba-42e6-9706-47b4f36049c3">
 
I modified the link to go to https://opensearch.org/events/ instead which is the upcoming events page.

### Issues Resolved
(no issue)

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
