### PR TITLE
UserGroups added to navbar

### DIFF
--- a/_data/header_navmenu_datafile.json
+++ b/_data/header_navmenu_datafile.json
@@ -307,6 +307,13 @@
                             "URL": "/community/members/index.html",
                             "ClassValue" : "drawer-content-subheader-link",
                             "Icon": "OpenSearch-Members-condensedImage"
+                        },
+                        {
+                            "Name": "UserGroups",
+                            "SubText": "Join the OpenSearch Project Meetup Network",
+                            "URL": "https://www.meetup.com/pro/opensearchproject/",
+                            "ClassValue" : "drawer-content-subheader-link",
+                            "Icon": "OpenSearch-UserGroups-condensedImage"
                         }
 
                     ]


### PR DESCRIPTION
Usergroups were added to the community section of the navbar.

### Description
Added usergroups to the navbar under the community section. 
The link points to the OpenSearch meetup page for now. 
 
### Issues Resolved
#3187 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
