### PR TITLE
Add blog url as part of subtext of roadmap

### DIFF
--- a/_data/header_navmenu_datafile.json
+++ b/_data/header_navmenu_datafile.json
@@ -413,7 +413,7 @@
                 {
                     "Title": "OpenSearch Project Roadmap",
                     "ClassValue": "drawer-content-subheader-link",
-                    "SubText": "Read our <a href=\"http://127.0.0.1:4000/blog/opensearch-project-roadmap-2024-2025/\">blog</a> on project development plan for 2024-2025 and beyond!",
+                    "SubText": "Read our <a href=\"blog/opensearch-project-roadmap-2024-2025/\">blog</a> on project development plan for 2024-2025 and beyond!",
                     "URL": "https://github.com/orgs/opensearch-project/projects/206",
                     "Roadmap_HeroBanner": "/assets/img/roadmap-graphic.png",
                     "Roadmap_Link": "https://github.com/orgs/opensearch-project/projects/206"

--- a/_data/header_navmenu_datafile.json
+++ b/_data/header_navmenu_datafile.json
@@ -413,7 +413,7 @@
                 {
                     "Title": "OpenSearch Project Roadmap",
                     "ClassValue": "drawer-content-subheader-link",
-                    "SubText": "Read our <a href=\"blog/opensearch-project-roadmap-2024-2025/\">blog</a> on project development plan for 2024-2025 and beyond!",
+                    "SubText": "Read our <a href=\"blog/opensearch-project-roadmap-2024-2025/\">blog</a> on 2024-2025 project development plan and beyond!",
                     "URL": "https://github.com/orgs/opensearch-project/projects/206",
                     "Roadmap_HeroBanner": "/assets/img/roadmap-graphic.png",
                     "Roadmap_Link": "https://github.com/orgs/opensearch-project/projects/206"

--- a/_data/header_navmenu_datafile.json
+++ b/_data/header_navmenu_datafile.json
@@ -413,7 +413,7 @@
                 {
                     "Title": "OpenSearch Project Roadmap",
                     "ClassValue": "drawer-content-subheader-link",
-                    "SubText": "Project development plan for 2024-2025 and beyond",
+                    "SubText": "Read our <a href=\"http://127.0.0.1:4000/blog/opensearch-project-roadmap-2024-2025/\">blog</a> on project development plan for 2024-2025 and beyond!",
                     "URL": "https://github.com/orgs/opensearch-project/projects/206",
                     "Roadmap_HeroBanner": "/assets/img/roadmap-graphic.png",
                     "Roadmap_Link": "https://github.com/orgs/opensearch-project/projects/206"


### PR DESCRIPTION
### Description
Add blog url as part of subtext of roadmap

![Screenshot 2024-10-04 at 7 07 12 PM](https://github.com/user-attachments/assets/79898d4d-412f-42d9-804e-44e4204cfb0b)


Specifically arrange this way so it wont be blocked by the picture on the right.
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
