### PR TITLE
btn hover state was missing for text

### DIFF
--- a/_sass/_navbar.scss
+++ b/_sass/_navbar.scss
@@ -110,6 +110,7 @@
     }
     &:hover {
         background-color: $primary-open-sky-s3;
+        color: $secondary-sanfrancisco-fog-t1;
     }
     &:active > .button-content {
 


### PR DESCRIPTION
### Description
The hover state was missing, I missed this because the "visited state" was set as the same as hover.
If someone has not previously clicked this link, it had no hover styling applied.

Fix was to apply a hover state to this button. 
 
### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
