### PR TITLE
Add border styling and padding to blog images

### DIFF
--- a/_sass/_opensearch.scss
+++ b/_sass/_opensearch.scss
@@ -102,13 +102,11 @@
 .img-fluid {
     max-width: 100%;
     height: auto;
-    border: 1px solid $line-lighter;
 }
 .img-centered {
     max-width: 100%;
     margin: 0 auto;
     display: block;
-    border: 1px solid $line-lighter;
 }
 .downloads-page {
     .layout-2col {
@@ -506,7 +504,14 @@
 }
 
 .page--blog-post {
-
+    #content-main {
+        img {
+            padding: 10px;
+            border: 1px solid $line-lighter;
+            border-radius: 4px;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
+        }
+    }
 
     .highlight pre, .highlight code {
         border: none;


### PR DESCRIPTION
For blog images, this PR adds:
- A rounded border with a shadow
- Padding 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
