### PR TITLE
Removed popper and switched the javascript include.

### DIFF
--- a/_includes/bootstrap-includes.html
+++ b/_includes/bootstrap-includes.html
@@ -1,3 +1,2 @@
 <link rel="stylesheet"  href="/assets/css/bootstrap.min.css">
-<script src="https://unpkg.com/@popperjs/core@2"></script>
-<script src="/assets/js/bootstrap.js"></script>
+<script src="/assets/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
the bundle.min.js includes popper, which bootstrap uses to render certain elements through javascript. Specifically dropdown elements.

### Description
Removed the unpkg script that was loading the bootstrap javascript externally. 
Switched the include statement to the correct bootstrap bundle.min.js. 
 
### Issues Resolved
#3385 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
