### PR TITLE
Release volley for 1.3.20-ga

### DIFF
--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-docker-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-docker-arm64.markdown
@@ -1,0 +1,11 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: docker
+architecture: arm64
+slug: opensearch-1.3.20-docker-arm64
+category: opensearch
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch/tags?page=1&ordering=last_updated&name=1.3.20
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-freebsd-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-freebsd-arm64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: freebsd
+architecture: arm64
+slug: opensearch-1.3.20-freebsd-arm64
+category: opensearch
+type: system-package
+freebsd_package_name: opensearch
+link: https://www.freshports.org/textproc/opensearch
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64-deb.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64-deb.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: arm64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-arm64.deb
+slug: opensearch-1.3.20-linux-arm64-deb
+category: opensearch
+type: deb
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-arm64.deb.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64-rpm.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: arm64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-arm64.rpm
+slug: opensearch-1.3.20-linux-arm64-rpm
+category: opensearch
+type: rpm
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-arm64.rpm.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64-yum.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64-yum.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: arm64
+slug: opensearch-1.3.20-linux-arm64-yum
+category: opensearch
+type: yum
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-linux-arm64.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: arm64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-arm64.tar.gz
+
+slug: opensearch-1.3.20-linux-arm64
+category: opensearch
+type: targz
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-arm64.tar.gz.sig
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-min-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-1.3.20-min-linux-arm64.markdown
@@ -1,0 +1,15 @@
+---
+role: daemon
+artifact_id: opensearch-min
+version: 1.3.20
+platform: linux
+architecture: arm64
+slug: opensearch-1.3.20-min-linux-arm64
+category: opensearch
+type: targz
+
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch/1.3.20/opensearch-min-1.3.20-linux-arm64.tar.gz
+signature: https://artifacts.opensearch.org/releases/core/opensearch/1.3.20/opensearch-min-1.3.20-linux-arm64.tar.gz.sig
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-docker-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-docker-arm64.markdown
@@ -1,0 +1,11 @@
+---
+role: ui
+artifact_id: opensearch-dashboards
+version: 1.3.20
+platform: docker
+architecture: arm64
+slug: opensearch-dashboards-1.3.20-docker-arm64
+category: opensearch-dashboards
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch-dashboards/tags?page=1&ordering=last_updated&name=1.3.20
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64-deb.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64-deb.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: deb
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-arm64.deb
+version: 1.3.20
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-arm64-deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-arm64.deb.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64-rpm.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-arm64.rpm
+version: 1.3.20
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-arm64-rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-arm64.rpm.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64-yum.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64-yum.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: yum
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo
+version: 1.3.20
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-arm64-yum
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-linux-arm64.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: arm64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-arm64.tar.gz
+version: 1.3.20
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-arm64
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-arm64.tar.gz.sig
+---
+

--- a/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-min-linux-arm64.markdown
+++ b/_artifacts/opensearch-1.3/arm64/opensearch-dashboards-1.3.20-min-linux-arm64.markdown
@@ -1,0 +1,15 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards-min
+architecture: arm64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.20/opensearch-dashboards-min-1.3.20-linux-arm64.tar.gz
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-min-linux-arm64
+signature: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.20/opensearch-dashboards-min-1.3.20-linux-arm64.tar.gz.sig
+version: 1.3.20
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-docker-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-docker-x64.markdown
@@ -1,0 +1,11 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: docker
+architecture: x64
+slug: opensearch-1.3.20-docker-x64
+category: opensearch
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch/tags?page=1&ordering=last_updated&name=1.3.20
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-freebsd-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-freebsd-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: freebsd
+architecture: x64
+slug: opensearch-1.3.20-freebsd-x64
+category: opensearch
+type: system-package
+freebsd_package_name: opensearch
+link: https://www.freshports.org/textproc/opensearch
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64-deb.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64-deb.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-x64.deb
+slug: opensearch-1.3.20-linux-x64-deb
+category: opensearch
+type: deb
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-x64.deb.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64-rpm.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-x64.rpm
+slug: opensearch-1.3.20-linux-x64-rpm
+category: opensearch
+type: rpm
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-x64.rpm.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64-yum.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64-yum.markdown
@@ -1,0 +1,13 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: x64
+slug: opensearch-1.3.20-linux-x64-yum
+category: opensearch
+type: yum
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/opensearch-1.x.repo.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-linux-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-x64.tar.gz
+slug: opensearch-1.3.20-linux-x64
+category: opensearch
+type: targz
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-linux-x64.tar.gz.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-min-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-min-linux-x64.markdown
@@ -1,0 +1,14 @@
+---
+role: daemon
+artifact_id: opensearch-min
+version: 1.3.20
+platform: linux
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch/1.3.20/opensearch-min-1.3.20-linux-x64.tar.gz
+slug: opensearch-1.3.20-min-linux-x64
+category: opensearch
+type: targz
+signature: https://artifacts.opensearch.org/releases/core/opensearch/1.3.20/opensearch-min-1.3.20-linux-x64.tar.gz.sig
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-windows-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-1.3.20-windows-x64.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: windows
+architecture: x64
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-windows-x64.zip
+slug: opensearch-1.3.20-windows-x64
+category: opensearch
+type: zip
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch/1.3.20/opensearch-1.3.20-windows-x64.zip.sig
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-docker-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-docker-x64.markdown
@@ -1,0 +1,11 @@
+---
+role: ui
+artifact_id: opensearch-dashboards
+version: 1.3.20
+platform: docker
+architecture: x64
+slug: opensearch-dashboards-1.3.20-docker-x64
+category: opensearch-dashboards
+type: docker_hub
+link: https://hub.docker.com/r/opensearchproject/opensearch-dashboards/tags?page=1&ordering=last_updated&name=1.3.20
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64-deb.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64-deb.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: deb
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-x64.deb
+version: 1.3.20
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-x64-deb
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-x64.deb.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/deb
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64-rpm.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64-rpm.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: rpm
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-x64.rpm
+version: 1.3.20
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-x64-rpm
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-x64.rpm.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64-yum.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64-yum.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: yum
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo
+version: 1.3.20
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-x64-yum
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.x/opensearch-dashboards-1.x.repo.sig
+guide: https://opensearch.org/docs/latest/opensearch/install/rpm
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-linux-x64.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-x64.tar.gz
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-linux-x64
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-linux-x64.tar.gz.sig
+version: 1.3.20
+---
+

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-min-linux-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-min-linux-x64.markdown
@@ -1,0 +1,15 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards-min
+architecture: x64
+platform: linux
+type: targz
+artifact_url: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.20/opensearch-dashboards-min-1.3.20-linux-x64.tar.gz
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-min-linux-x64
+signature: https://artifacts.opensearch.org/releases/core/opensearch-dashboards/1.3.20/opensearch-dashboards-min-1.3.20-linux-x64.tar.gz.sig
+version: 1.3.20
+security_warning: true
+indirect: true
+---

--- a/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-windows-x64.markdown
+++ b/_artifacts/opensearch-1.3/x64/opensearch-dashboards-1.3.20-windows-x64.markdown
@@ -1,0 +1,14 @@
+---
+role: ui
+title: OpenSearch Dashboards
+artifact_id: opensearch-dashboards
+architecture: x64
+platform: windows
+type: zip
+artifact_url: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-windows-x64.zip
+category: opensearch-dashboards
+slug: opensearch-dashboards-1.3.20-windows-x64
+signature: https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.3.20/opensearch-dashboards-1.3.20-windows-x64.zip.sig
+version: 1.3.20
+---
+

--- a/_artifacts/opensearch-1.3/x86/opensearch-1.3.20-freebsd-x86.markdown
+++ b/_artifacts/opensearch-1.3/x86/opensearch-1.3.20-freebsd-x86.markdown
@@ -1,0 +1,12 @@
+---
+role: daemon
+artifact_id: opensearch
+version: 1.3.20
+platform: freebsd
+architecture: x86
+slug: opensearch-1.3.20-freebsd-x86
+category: opensearch
+type: system-package
+freebsd_package_name: opensearch
+link: https://www.freshports.org/textproc/opensearch
+---

--- a/_versions/2024-12-10-opensearch-1.3.20.markdown
+++ b/_versions/2024-12-10-opensearch-1.3.20.markdown
@@ -1,0 +1,97 @@
+---
+date: "2024-12-10"
+product: opensearch
+version: '1.3.20'
+release_notes: https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-1.3.20.md
+version_sort: 1.3.20-ga
+components:
+  - role: daemon
+    artifact: opensearch
+    version: 1.3.20
+  - role: ui
+    artifact: opensearch-dashboards
+    version: 1.3.20
+  - role: command-line-tools
+    artifact: opensearch-cli
+    version: 1.2.0
+  - role: sql-command-line
+    artifact: opensearch-sql-cli
+    version: 1.0.0
+    platform_order:
+      - python
+  - role: ingest
+    artifact: data-prepper
+    version: data-prepper-2.10.1
+    platform_order:
+      - docker
+      - linux
+  - role: ingest
+    artifact: logstash-oss-with-opensearch-output-plugin
+    version: 8.6.1
+  - role: minimal-artifacts
+    artifact: opensearch-min
+    version: 1.3.20
+  - role: minimal-artifacts
+    artifact: opensearch-dashboards-min
+    version: 1.3.20
+  - role: drivers
+    artifact: opensearch-sql-odbc
+    version: 1.1.0.1
+  - role: drivers
+    artifact: opensearch-sql-jdbc
+    version: 1.4.0.1
+sections:
+  docker-compose:
+    explanation: "downloads/opensearch-docker-1.x.markdown"
+  opensearch:
+    role: daemon
+    artifacts:
+      opensearch:
+        explanation: "downloads/opensearch-daemon.markdown"
+  opensearch-dashboards:
+    role: ui
+    artifacts:
+      opensearch-dashboards:
+        explanation: "downloads/opensearch-ui.markdown"
+  data-ingest:
+    explanation: "downloads/opensearch-data-ingest.markdown"
+    role: ingest
+    artifacts:
+      data-prepper:
+        explanation: "downloads/data-prepper.html"
+      logstash-oss-with-opensearch-output-plugin:
+        explanation: "downloads/logstash-oss-with-opensearch-output-plugin.markdown"
+  command-line-tools:
+    role: command-line-tools
+    artifacts:
+      opensearch-cli:
+        explanation: "downloads/opensearch-cli.html"
+  sql-command-line:
+    role: sql-command-line
+    artifacts:
+      opensearch-sql-cli:
+        explanation: "downloads/opensearch-sql-cli.markdown"
+  drivers:
+    explanation: "downloads/drivers.markdown"
+    role: drivers
+    artifacts:
+      opensearch-sql-odbc:
+        explanation: "downloads/odbc.markdown"
+      opensearch-sql-jdbc:
+        explanation: "downloads/jdbc.markdown"
+  minimal:
+    explanation: "downloads/minimal-distributions.markdown"
+    role: minimal-artifacts
+    artifacts:
+      opensearch-min:
+        explanation: "downloads/opensearch-daemon-min.markdown"
+      opensearch-dashboards-min:
+        explanation: "downloads/opensearch-ui-min.markdown"
+pretty:
+  artifacts:
+    opensearch: ''
+    opensearch-min: 'OpenSearch Minimum'
+    opensearch-dashboards: ''
+    opensearch-dashboards-min: 'OpenSearch Dashboards Minimum'
+---
+OpenSearch is open source software that uses the Apache License version 2 (ALv2). ALv2 grants you well-understood usage rights; you can use, modify, extend, embed, monetize, resell, and offer OpenSearch as part of your products and services. The source for the entire project is available on [GitHub](https://github.com/opensearch-project/) and you're welcome to build from source for customized deployments. Downloadable artifacts for OpenSearch and OpenSearch Dashboards include plugins and tools, ready for you to use with minimal configuration.

--- a/_versions/2024-12-10-opensearch-1.3.20.markdown
+++ b/_versions/2024-12-10-opensearch-1.3.20.markdown
@@ -1,5 +1,5 @@
 ---
-date: "2024-12-10"
+date: "2024-12-11"
 product: opensearch
 version: '1.3.20'
 release_notes: https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-1.3.20.md


### PR DESCRIPTION
### Description
Artifacts and version markdowns for the release of 1.3.20 today (12.10.2024)
 



By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
