### PR TITLE
Data prepper 2.10.2 for Opensearch 1.3.20

### DIFF
--- a/_versions/2024-12-10-opensearch-1.3.20.markdown
+++ b/_versions/2024-12-10-opensearch-1.3.20.markdown
@@ -21,7 +21,7 @@ components:
       - python
   - role: ingest
     artifact: data-prepper
-    version: data-prepper-2.10.1
+    version: data-prepper-2.10.2
     platform_order:
       - docker
       - linux


### PR DESCRIPTION
### Description
Data prepper 2.10.2 on OS 1.3.20 download page. 
 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
