### PR TITLE
NAVBAR - Remove the script that changes all calendar links

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -700,7 +700,7 @@
 
 </div>
 
-<script type="module">
+<!-- <script type="module">
 
     // Initialize the calendar view menu item to target the current month's calendar
     document.addEventListener('DOMContentLoaded', () => {
@@ -712,5 +712,5 @@
         eventsLinkSelector.setAttribute("href", `/events/calendar/${year}/${month.toLowerCase()}/`);
 
     });
-</script>
+</script> -->
 


### PR DESCRIPTION




### Description
commented out, instead of deleting. So that when we get the calendar fixed we can put this back.
 
Image shows that the link has been updated to just point to "/events/"
![image](https://github.com/user-attachments/assets/e7f25b06-ad55-4a9b-ba96-dd54e33db0f2)

### Issues Resolved
n/a

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
