### PR TITLE
Slack url update - FB link removal

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,9 +39,6 @@
                         <a href="https://www.youtube.com/c/OpenSearchProject" class="text-reset btn btn-icon">
                           {% include icons.html type='youtube-social' %}
                         </a>
-                        <a href="https://www.facebook.com/OpenSearchProject/" class="text-reset btn btn-icon">
-                          {% include icons.html type='facebook-social' %}
-                        </a>
                         <a href="https://www.linkedin.com/company/opensearch-project/" class="text-reset btn btn-icon">
                           {% include icons.html type='linkedin-social' %}
                         </a>

--- a/_includes/redesign_buttons.html
+++ b/_includes/redesign_buttons.html
@@ -169,7 +169,7 @@
         </div>
     {% when 'join-slack' %}
         <div class="redesign-button--wrapper redesign-button--wrapper__text-only__dark">
-            <a target="_blank" href="https://join.slack.com/t/opensearch/shared_invite/zt-2sp09njae-t1y6M6dQ3_uKjDVYkMHCyw" class="redesign-button--anchor" id="join-slack-button">
+            <a target="_blank" href="https://join.slack.com/t/opensearch/shared_invite/zt-2y8hag1x1-WDK3344iNXv1GHlZHQ~coQ" class="redesign-button--anchor" id="join-slack-button">
                 Join the Conversation
             </a>
         </div>


### PR DESCRIPTION
### Description
Updated invitation link for the Slack page
Removal of Facebook link - no longer in use by the project
 
### Issues Resolved
https://github.com/opensearch-project/project-website/issues/3564
https://github.com/opensearch-project/project-website/issues/3526 (partially resolved) 

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
