### PR TITLE
Add tutorials in 'OpenSearch now supports DeepSeek chat models' Blog

### DIFF
--- a/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
+++ b/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
@@ -260,6 +260,7 @@ The response contains the model output:
 }
 ```
 ## Tutorials
+
 The following tutorials guide you through integrating RAG in OpenSearch with the [DeepSeek chat model](https://api-docs.deepseek.com/api/create-chat-completion) and [DeepSeek R1 model](https://huggingface.co/deepseek-ai/DeepSeek-R1):
 - [OpenSearch + DeepSeek Service API](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_Chat_model.md)
 - [OpenSearch + DeepSeek on Amazon Bedrock](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Bedrock.md)

--- a/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
+++ b/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
@@ -260,10 +260,10 @@ The response contains the model output:
 }
 ```
 ## Tutorials
-Following are the tutorials for integrating retrieval-augmented generation (RAG) in Amazon OpenSearch with [DeepSeek Chat Model](https://api-docs.deepseek.com/api/create-chat-completion) and [DeepSeek R1 Model](https://huggingface.co/deepseek-ai/DeepSeek-R1):
+The following tutorials guide you through integrating RAG in OpenSearch with the [DeepSeek chat model](https://api-docs.deepseek.com/api/create-chat-completion) and [DeepSeek R1 model](https://huggingface.co/deepseek-ai/DeepSeek-R1):
 - [OpenSearch + DeepSeek Service API](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_Chat_model.md)
-- [OpenSearch + DeepSeek on Bedrock](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Bedrock.md)
-- [OpenSearch + DeepSeek on Sagemaker](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Sagemaker.md)
+- [OpenSearch + DeepSeek on Amazon Bedrock](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Bedrock.md)
+- [OpenSearch + DeepSeek on Amazon SageMaker](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Sagemaker.md)
 
 ## Wrapping up
 

--- a/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
+++ b/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
@@ -259,6 +259,11 @@ The response contains the model output:
   }
 }
 ```
+## Tutorials
+Following are the tutorials for integrating retrieval-augmented generation (RAG) in Amazon OpenSearch with [DeepSeek Chat Model](https://api-docs.deepseek.com/api/create-chat-completion) and [DeepSeek R1 Model](https://huggingface.co/deepseek-ai/DeepSeek-R1):
+- [OpenSearch + DeepSeek Service API](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_Chat_model.md)
+- [OpenSearch + DeepSeek on Bedrock](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Bedrock.md)
+- [OpenSearch + DeepSeek on Sagemaker](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Sagemaker.md)
 
 ## Wrapping up
 

--- a/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
+++ b/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
@@ -262,6 +262,7 @@ The response contains the model output:
 ## Tutorials
 
 The following tutorials guide you through integrating RAG in OpenSearch with the [DeepSeek chat model](https://api-docs.deepseek.com/api/create-chat-completion) and [DeepSeek R1 model](https://huggingface.co/deepseek-ai/DeepSeek-R1):
+
 - [OpenSearch + DeepSeek Chat Service API](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_Chat_model.md)
 - [OpenSearch + DeepSeek R1 on Amazon Bedrock](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Bedrock.md)
 - [OpenSearch + DeepSeek R1 on Amazon SageMaker](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Sagemaker.md)

--- a/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
+++ b/_posts/2025-01-28-OpenSearch-Now-Supports-DeepSeek-Chat-Models.md
@@ -262,9 +262,9 @@ The response contains the model output:
 ## Tutorials
 
 The following tutorials guide you through integrating RAG in OpenSearch with the [DeepSeek chat model](https://api-docs.deepseek.com/api/create-chat-completion) and [DeepSeek R1 model](https://huggingface.co/deepseek-ai/DeepSeek-R1):
-- [OpenSearch + DeepSeek Service API](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_Chat_model.md)
-- [OpenSearch + DeepSeek on Amazon Bedrock](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Bedrock.md)
-- [OpenSearch + DeepSeek on Amazon SageMaker](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Sagemaker.md)
+- [OpenSearch + DeepSeek Chat Service API](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_Chat_model.md)
+- [OpenSearch + DeepSeek R1 on Amazon Bedrock](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Bedrock.md)
+- [OpenSearch + DeepSeek R1 on Amazon SageMaker](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/aws/RAG_with_DeepSeek_R1_model_on_Sagemaker.md)
 
 ## Wrapping up
 


### PR DESCRIPTION
### Description
Add some tutorials into this [blog post](https://opensearch.org/blog/OpenSearch-Now-Supports-DeepSeek-Chat-Models/).
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
