### PR TITLE
fix links for blog "A deep dive into faster semantic sparse retrieval in OpenSearch 2.12"

### DIFF
--- a/_posts/2023-12-05-improving-document-retrieval-with-sparse-semantic-encoders.md
+++ b/_posts/2023-12-05-improving-document-retrieval-with-sparse-semantic-encoders.md
@@ -485,6 +485,6 @@ Use the following recommendations to select a sparse encoding model:
 
 Read more about neural sparse search:
 
-1. [A deep dive into faster semantic sparse retrieval in OpenSearch 2.12]({{site.baseurl}}/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12)
+1. [A deep dive into faster semantic sparse retrieval in OpenSearch 2.12]({{site.baseurl}}/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12/)
 1. [Introducing the neural sparse two-phase algorithm]({{site.baseurl}}/blog/Introducing-a-neural-sparse-two-phase-algorithm)
 1. [Advancing Search Quality and Inference Speed with v2 Series Neural Sparse Models]({{site.baseurl}}/blog/neural-sparse-v2-models)

--- a/_posts/2024-08-07-Introducing-a-neural-sparse-two-phase-algorithm.md
+++ b/_posts/2024-08-07-Introducing-a-neural-sparse-two-phase-algorithm.md
@@ -125,5 +125,5 @@ For more information about the two-phase processor, see [Neural sparse query two
 Read more about neural sparse search:
 
 1. [Improving document retrieval with sparse semantic encoders]({{site.baseurl}}/blog/improving-document-retrieval-with-sparse-semantic-encoders)
-1. [A deep dive into faster semantic sparse retrieval in OpenSearch 2.12]({{site.baseurl}}/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12)
+1. [A deep dive into faster semantic sparse retrieval in OpenSearch 2.12]({{site.baseurl}}/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12/)
 1. [Advancing Search Quality and Inference Speed with v2 Series Neural Sparse Models]({{site.baseurl}}/blog/neural-sparse-v2-models)

--- a/_posts/2024-08-19-neural-sparse-v2-models.md
+++ b/_posts/2024-08-19-neural-sparse-v2-models.md
@@ -171,7 +171,7 @@ To register and deploy models in bi-encoder mode, use the following steps.
 For more information about neural sparse search, see these previous blog posts:
 
 - [Improving document retrieval with sparse semantic encoders]({{site.baseurl}}/blog/improving-document-retrieval-with-sparse-semantic-encoders)
-- [A deep dive into faster semantic sparse retrieval in OpenSearch 2.12]({{site.baseurl}}/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12)
+- [A deep dive into faster semantic sparse retrieval in OpenSearch 2.12]({{site.baseurl}}/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12/)
 - [Introducing the neural sparse two-phase algorithm]({{site.baseurl}}/blog/Introducing-a-neural-sparse-two-phase-algorithm)
 
 ---


### PR DESCRIPTION
### Description
Change the URL from  https://opensearch.org/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12 to https://opensearch.org/blog/A-deep-dive-into-faster-semantic-sparse-retrieval-in-OS-2.12/ in the blog links.
 
### Issues Resolved
#3522 

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
