### PR TITLE
Change order of release versions to bump 3.0

### DIFF
--- a/release-dashboard/index.md
+++ b/release-dashboard/index.md
@@ -12,12 +12,15 @@ breadcrumbs:
 omit_from_search: true
 
 release_versions:
-  - version: 2.19.0
-    release_issue: 5152
-    release_retro_issue: 5153
+  - version: 2.19.1
+    release_issue: 5323
+    release_retro_issue: 5324
   - version: 3.0.0
     release_issue: 3747
     release_retro_issue: 5174
+  - version: 2.19.0
+    release_issue: 5152
+    release_retro_issue: 5153
   - version: 2.18.0
     release_issue: 5004
     release_retro_issue: 5005


### PR DESCRIPTION
### Description
Change order of release versions to bump 3.0, as 2.19 is closed
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/5152

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
