### PR TITLE
Fix the author for bitmap filtering blog

### DIFF
--- a/_community_members/bowenlan.md
+++ b/_community_members/bowenlan.md
@@ -1,0 +1,15 @@
+---
+short_name: bowenlan
+name: Bowen Lan
+github: bowenlan-amzn
+photo: /assets/media/community/members/bowenlan.jpeg
+title: "OpenSearch Project Community Member: Bowen Lan "
+primary_title: Bowen Lan
+permalink: /community/members/bowenlan.html
+job_title_and_company: "Software Engineer at AWS"
+personas:
+  - author
+
+---
+
+**Bowen Lan** is a software engineer at AWS focusing on OpenSearch.

--- a/_posts/2025-02-04-introduce-bitmap-filtering-feature.md
+++ b/_posts/2025-02-04-introduce-bitmap-filtering-feature.md
@@ -2,9 +2,9 @@
 layout: post
 title:  "Efficient large-scale filtering with bitmap filtering in OpenSearch"
 authors:
-   - bowenlan-amzn
+   - bowenlan
    - macrakis
-   - msfroh
+   - mfroh
    - kolchfa
 date: 2025-02-25
 categories:


### PR DESCRIPTION
### Description
Notice that Froh and I don't show up as author in the blog
https://opensearch.org/blog/introduce-bitmap-filtering-feature/

This PR try to fix the problem
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
