### PR TITLE
[prod] Keeps 2.19.1 as 'latest' version by removing version_sort metadata on 3.0.0-alpha1.

### DIFF
--- a/_posts/2025-03-18-GPU-Accelerated-Vector-Search-OpenSearch-New-Frontier.md
+++ b/_posts/2025-03-18-GPU-Accelerated-Vector-Search-OpenSearch-New-Frontier.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "GPU-accelerated vector search in Opensearch: A new frontier" 
+title:  "GPU-accelerated vector search in OpenSearch: A new frontier" 
 authors:
   - navneev
   - cnolet

--- a/_versions/2025-03-18-opensearch-3.0.0-alpha1.markdown
+++ b/_versions/2025-03-18-opensearch-3.0.0-alpha1.markdown
@@ -3,7 +3,7 @@ date: "2025-03-18"
 product: opensearch
 version: '3.0.0-alpha1'
 release_notes: https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-3.0.0-alpha1.md
-version_sort: 3.0.0-alpha1
+#version_sort: 3.0.0-alpha1
 components:
   - role: daemon
     artifact: opensearch


### PR DESCRIPTION
### Description
Keeps 2.19.1 as 'latest' version by removing version_sort metadata on 3.0.0-alpha1. 


### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
