### PR TITLE
fix image link for redline testing blog

### DIFF
--- a/_posts/2025-04-24-Redline-Testing-Comes-to-OpenSearch-Benchmark.md
+++ b/_posts/2025-04-24-Redline-Testing-Comes-to-OpenSearch-Benchmark.md
@@ -58,7 +58,8 @@ The following diagram provides a high-level overview of the actor-based executio
 - **BenchmarkActor**: Initiates the benchmarking process.  
 - **WorkerCoordinatorActor**: Manages worker lifecycle and task distribution using an allocation matrix from the **Allocator**.  
 - **Workers (Worker1 through WorkerN)**: Executes tasks by managing clients through the **AsyncIoAdapter**.  
-- **Clients (Client1 through ClientN)**: Uses the `AsyncExecutor` class to perform operations against the target host in parallel. 
+- **Clients (Client1 through ClientN)**: Uses the `AsyncExecutor` class to perform operations against the target host in parallel.
+
 ![Flowchart for OpenSearch Benchmark's actor system](/assets/media/blog-images/2025-04-24-Redline-Testing-Comes-to-OpenSearch-Benchmark/OSB-system-architecture.jpg){: .img-fluid}
 
 OpenSearch Benchmark uses the **Actor Model**, which structures concurrent, distributed systems around isolated, message-passing components.


### PR DESCRIPTION
### Description
Fixes the image link for new [redline testing blog post](https://opensearch.org/blog/redline-testing-now-available-in-opensearch-benchmark/)
 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
