### PR TITLE
Adds a release blog for Data Prepper 2.13. Resolves #4015.

### DIFF
--- a/_posts/2025-11-24-Data-Prepper-2.13-is-now-available.md
+++ b/_posts/2025-11-24-Data-Prepper-2.13-is-now-available.md
@@ -4,7 +4,7 @@ title: Data Prepper 2.13 is now available
 authors:
   - kkondaka
   - dvenable
-date: 2025-11-24 14:00:00 -0600
+date: 2025-11-25 14:00:00 -0600
 categories:
   - releases
 excerpt: Data Prepper 2.13 introduces Amazon Managed Prometheus sink support, native OpenSearch data streams, cross-region S3, and performance improvements delivering.


### PR DESCRIPTION
### Description

This adds the release blog to announce Data Prepper 2.13. We plan to release on Nov 24, 2025.
 
### Issues Resolved

Resolves #4015.

### Check List
- [x] Commits are signed per the DCO using --signoff
- [x] Extract Thank You section.


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
