### PR TITLE
Remove editorial step from blog process

### DIFF
--- a/.github/workflows/process-new-blog.yml
+++ b/.github/workflows/process-new-blog.yml
@@ -36,7 +36,7 @@ jobs:
           body: |
             Thank you for submitting a blog post!
             
-            The blog post review process is: Submit a PR -> (Optional) Peer review -> Doc review -> Editorial review -> Marketing review -> Published.
+            The blog post review process is: Submit a PR -> (Optional) Peer review -> Doc review -> Marketing review -> Published.
 
       - name: Check for linked issues
         if: steps.check-new-blog.outputs.is_new_blog == 'true'

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The blog post review process is as follows:
 1. Create a PR containing the blog post content. See the [BLOG_GUIDE](BLOG_GUIDE.md) to learn how to format a blog post and add authors. 
 1. (Optional) Have one of your peers conduct a technical review.
 1. A technical writer performs a doc review.
-1. The editor performs an editorial review.
 1. Marketing conducts a final review and provides the blog meta.
 1. The blog is published.
 


### PR DESCRIPTION
Remove editorial step from blog process

### Check List
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the BSD-3-Clause License.
