### PR TITLE
docs: add Observability Stack to downloads page

### DIFF
--- a/_includes/downloads/opensearch-docker.markdown
+++ b/_includes/downloads/opensearch-docker.markdown
@@ -11,7 +11,7 @@ The best way to try out OpenSearch is to use [Docker Compose](https://docs.docke
 5. Navigate to [http://localhost:5601/](http://localhost:5601) for OpenSearch Dashboards
 6. Login with the default username (`admin`) and password (`<custom-admin-password>`)
 
-**Looking for full observability out of the box?** The [Observability Stack](https://github.com/opensearch-project/observability-stack) is an OpenTelemetry-native platform that bundles OpenSearch, Dashboards, Data Prepper, and an OTel Collector with pre-configured dashboards for traces, logs, metrics, and AI agent observability:
+**Looking for full observability out of the box?** The [Observability Stack](https://github.com/opensearch-project/observability-stack) is an OpenTelemetry-native platform that bundles OpenSearch, Dashboards, Data Prepper, and an OpenTelemetry Collector with preconfigured dashboards for traces, logs, metrics, and AI agent observability. To install the Observability Stack, run the following command:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/opensearch-project/observability-stack/main/install.sh | bash


### PR DESCRIPTION
### Description

Adds a callout to the [Observability Stack](https://observability.opensearch.org/) in the **Try OpenSearch with Docker Compose** section of the downloads page.

The Observability Stack is an OpenTelemetry-native platform that bundles OpenSearch, Dashboards, Data Prepper, and an OTel Collector with pre-configured dashboards for traces, logs, metrics, and AI agent observability.

### Changes

- 1 file changed: `_includes/downloads/opensearch-docker.markdown` (+8 lines)
- Appends a brief callout at the bottom of the existing Docker Compose section
- Links to the one-command installer and [observability.opensearch.org](https://observability.opensearch.org/) docs


<img width="1465" height="1009" alt="Screenshot of observability stack callout in docs page" src="https://github.com/user-attachments/assets/08ee4cbf-47e4-4e09-a9f9-01e472d581e8" />


### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.