### PR TITLE
Add Agent Health to downloads page

### DIFF
--- a/_artifacts/agent-health/agent-health-1.0.0.markdown
+++ b/_artifacts/agent-health/agent-health-1.0.0.markdown
@@ -1,0 +1,16 @@
+---
+role: agent-health
+artifact_id: agent-health
+version: 1.0.0
+platform: javascript
+type: javascript
+architecture: npm
+slug: agent-health-1.0.0
+category: opensearch
+inline_instructions:
+- label: "Command To Install"
+  code: npx @opensearch-project/agent-health
+  link:
+    label: View on npm
+    url: https://www.npmjs.com/package/@opensearch-project/agent-health
+---

--- a/_includes/downloads/agent-health.markdown
+++ b/_includes/downloads/agent-health.markdown
@@ -1,0 +1,1 @@
+<p><a href="https://github.com/opensearch-project/agent-health">Agent Health</a> is an evaluation and observability framework for AI agents. It provides real-time agent execution streaming, LLM-based evaluation with pass/fail scoring, batch experiments for comparing agents and models, and OpenTelemetry trace integration for performance analysis.</p>

--- a/_layouts/versions.html
+++ b/_layouts/versions.html
@@ -21,6 +21,7 @@ pretty:
     data-prepper-no-jdk: OpenSearch Data Prepper (without bundled JDK)
     logstash-oss-with-opensearch-output-plugin: Logstash OSS with OpenSearch Output Plugin
     opensearch-sql-cli: SQL-CLI
+    agent-health: Agent Health
   platforms:
     windows: "Windows"
     linux: "Linux"
@@ -30,6 +31,7 @@ pretty:
     docker: Docker
     archlinux: "Arch Linux"
     python: "Python"
+    javascript: "Node.js"
   extensions:
     targz: ".tar.gz"
     exe: "Installer (exe)"
@@ -40,18 +42,21 @@ pretty:
     docker_hub: 'Dockerfile'
     system-package: "System package"
     python: ".tar.gz"
+    javascript: "npm"
   architectures:
     arm64: "ARM64"
     x64: "x64"
     x86: "x86"
     jvm: Java Virtual Machine
     python: "pypi"
+    npm: "npm"
   sections:
     opensearch: OpenSearch
     opensearch-dashboards: OpenSearch Dashboards
     command-line-tools: 'Command Line Tools'
     sql-command-line: 'OpenSearch SQL CLI'
     data-ingest: 'Ingest Tools'
+    agent-tools: 'AI Agent Tools'
     docker-compose: 'Try OpenSearch with Docker Compose'
     minimal: 'Minimal Distributions'
     drivers: "Drivers"
@@ -62,6 +67,7 @@ architecture_order:
   - x86
   - jvm
   - python
+  - npm
 
 platform_order:
   - linux
@@ -72,6 +78,7 @@ platform_order:
   - windows
   - java
   - python
+  - javascript
 ---
 
 {%comment%} 

--- a/_versions/2025-02-27-opensearch-2.19.1.markdown
+++ b/_versions/2025-02-27-opensearch-2.19.1.markdown
@@ -35,6 +35,11 @@ components:
   - role: sql-command-line
     artifact: opensearch-sql-cli
     version: 1.0.0
+  - role: agent-health
+    artifact: agent-health
+    version: 1.0.0
+    platform_order:
+      - javascript
 sections:
   docker-compose:
     explanation: "downloads/opensearch-docker.markdown"
@@ -64,6 +69,11 @@ sections:
     artifacts:
       opensearch-sql-cli:
         explanation: "downloads/opensearch-sql-cli.markdown"
+  agent-tools:
+    explanation: "downloads/agent-health.markdown"
+    role: agent-health
+    artifacts:
+      agent-health:
   drivers:
     explanation: "downloads/drivers.markdown"
     role: drivers

--- a/_versions/2025-03-18-opensearch-3.0.0-alpha1.markdown
+++ b/_versions/2025-03-18-opensearch-3.0.0-alpha1.markdown
@@ -35,6 +35,11 @@ components:
   - role: sql-command-line
     artifact: opensearch-sql-cli
     version: 1.0.0
+  - role: agent-health
+    artifact: agent-health
+    version: 1.0.0
+    platform_order:
+      - javascript
 sections:
   docker-compose:
     explanation: "downloads/opensearch-docker.markdown"
@@ -64,6 +69,11 @@ sections:
     artifacts:
       opensearch-sql-cli:
         explanation: "downloads/opensearch-sql-cli.markdown"
+  agent-tools:
+    explanation: "downloads/agent-health.markdown"
+    role: agent-health
+    artifacts:
+      agent-health:
   drivers:
     explanation: "downloads/drivers.markdown"
     role: drivers


### PR DESCRIPTION
## Description

Adds [Agent Health](https://github.com/opensearch-project/agent-health) as a new **AI Agent Tools** section on the downloads page, following the same pattern as the SQL CLI (PyPI) distribution.

## Changes

- Added `agent-health` artifact definition with npx install command and npm link
- Added "AI Agent Tools" section to the downloads layout and version files (2.19.1, 3.0.0-alpha1)
- Added Node.js platform and npm architecture support to the layout config

## Screenshot

<img width="1512" height="839" alt="Screenshot 2026-03-18 at 6 23 08 PM" src="https://github.com/user-attachments/assets/1f2d0a35-4fd2-4ee3-86dd-c3730f258a1a" />

## Issues Resolved

Related to #4096

## Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).