### PR TITLE
Update Peter Nied maintainer metadata

### DIFF
--- a/_community_members/peternied.md
+++ b/_community_members/peternied.md
@@ -14,11 +14,12 @@ breadcrumbs:
     - title: 'Peter Nied&apos;s Profile'
       url: '/community/members/peter-nied.html'
 github: peternied
-job_title_and_company: 'Software engineer at Amazon Web Services'
+email: peter.nied@airbnb.com
+job_title_and_company: 'Software engineer at Airbnb'
 personas:
   - author
 permalink: '/community/members/peter-nied.html'
 redirect_from: '/authors/peternied/'
 ---
 
-**Peter Nied** is a software engineer at Amazon Web Services focusing on OpenSearch security.
+**Peter Nied** is a software engineer at Airbnb focusing on OpenSearch security.


### PR DESCRIPTION
Updates Peter Nied's public maintainer metadata to use Airbnb affiliation and peter.nied@airbnb.com where the document supports an email field.